### PR TITLE
mem leak and stats bugfix

### DIFF
--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -109,7 +109,8 @@ class CachedPost:
         url = author+'/'+permlink
         if url in cls._queue:
             del cls._queue[url]
-            del cls._ids[url]
+            if url in cls._ids:
+                del cls._ids[url]
 
     @classmethod
     def undelete(cls, post_id, author, permlink):
@@ -170,7 +171,8 @@ class CachedPost:
         cls._update_batch(tuples, trx, full_total=full_total)
         for url, _, _ in tuples:
             del cls._queue[url]
-            del cls._ids[url]
+            if url in cls._ids:
+                del cls._ids[url]
 
         # TODO: ideal place to update reps of authors whos posts were modified.
         # potentially could be triggered in vote(). remove the Accounts.dirty

--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -109,6 +109,7 @@ class CachedPost:
         url = author+'/'+permlink
         if url in cls._queue:
             del cls._queue[url]
+            del cls._ids[url]
 
     @classmethod
     def undelete(cls, post_id, author, permlink):
@@ -169,6 +170,7 @@ class CachedPost:
         cls._update_batch(tuples, trx, full_total=full_total)
         for url, _, _ in tuples:
             del cls._queue[url]
+            del cls._ids[url]
 
         # TODO: ideal place to update reps of authors whos posts were modified.
         # potentially could be triggered in vote(). remove the Accounts.dirty

--- a/hive/utils/stats.py
+++ b/hive/utils/stats.py
@@ -163,11 +163,14 @@ class Stats:
         if cls._ms > cls.PRINT_THRESH_MINS * 60 * 1000:
             cls.report()
             cls._ms = 0
+            cls._idle = 0
             cls._start = perf()
 
     @classmethod
     def report(cls):
         """Emit a timing report for tracked services."""
+        if not cls._ms:
+            return # nothing to report
         local = cls._ms / 1000
         idle = cls._idle / 1000
         total = (perf() - cls._start)


### PR DESCRIPTION
 - The `_ids` deletion fixes unbounded mem growth; cherry-picked from `71-resync` (https://github.com/steemit/hivemind/pull/136/commits)
 - idle counter in stats is now reset appropriately 