### PR TITLE
Initial testnet support.

### DIFF
--- a/hive/db/db_state.py
+++ b/hive/db/db_state.py
@@ -5,6 +5,7 @@ import logging
 
 from hive.db.schema import setup, build_metadata, teardown, DB_VERSION
 from hive.db.adapter import Db
+from hive.steem.client import SteemClient
 
 log = logging.getLogger(__name__)
 
@@ -18,22 +19,26 @@ class DbState:
 
     # db schema version
     _ver = None
+    
+    _url = None
 
     @classmethod
-    def initialize(cls):
+    def initialize(cls, url='https://api.steemit.com'):
         """Perform startup database checks.
 
         1) Load schema if needed
         2) Run migrations if needed
         3) Check if initial sync has completed
         """
-
+        
         log.info("[INIT] Welcome to hive!")
-
+        cls.url = url
+        chain = 'testnet' if SteemClient(url).is_testnet() else 'mainnet'
+        
         # create db schema if needed
         if not cls._is_schema_loaded():
-            log.info("[INIT] Create db schema...")
-            setup(cls.db())
+            log.info("[INIT] Create db schema on %s ...", chain)
+            setup(cls.db(), chain)
             cls._before_initial_sync()
 
         # perform db migrations
@@ -207,9 +212,8 @@ class DbState:
 
         if cls._ver == 5:
             # recover acct names lost to issue #151
-            from hive.steem.client import SteemClient
             from hive.indexer.accounts import Accounts
-            names = SteemClient().get_all_account_names()
+            names = SteemClient(cls._url).get_all_account_names()
             Accounts.load_ids()
             Accounts.register(names, '1970-01-01T00:00:00')
             Accounts.clear_ids()

--- a/hive/indexer/accounts.py
+++ b/hive/indexer/accounts.py
@@ -145,11 +145,11 @@ class Accounts:
                 log.info(timer.batch_status())
 
     @classmethod
-    def _sql(cls, account, cached_at):
+    def _sql(cls, account, cached_at, chain='mainnet'):
         """Prepare a SQL query from a steemd account."""
-        vote_weight = (vests_amount(account['vesting_shares'])
-                       + vests_amount(account['received_vesting_shares'])
-                       - vests_amount(account['delegated_vesting_shares']))
+        vote_weight = (vests_amount(account['vesting_shares'], chain)
+                       + vests_amount(account['received_vesting_shares'], chain)
+                       - vests_amount(account['delegated_vesting_shares'], chain))
 
         # remove empty keys
         useless = ['transfer_history', 'market_history', 'post_history',
@@ -172,7 +172,7 @@ class Accounts:
             'proxy':        account['proxy'],
             'post_count':   account['post_count'],
             'reputation':   rep_log10(account['reputation']),
-            'proxy_weight': vests_amount(account['vesting_shares']),
+            'proxy_weight': vests_amount(account['vesting_shares'], chain),
             'vote_weight':  vote_weight,
             'active_at':    active_at,
             'cached_at':    cached_at,

--- a/hive/indexer/payments.py
+++ b/hive/indexer/payments.py
@@ -45,14 +45,16 @@ class Payments:
             CachedPost.vote(author, permlink, record['post_id'])
 
     @classmethod
-    def _validated(cls, op, tx_idx, num, date):
+    def _validated(cls, op, tx_idx, num, date, chain='mainnet'):
         """Validate and normalize the transfer op."""
         # pylint: disable=unused-argument
         if op['to'] != 'null':
             return # only care about payments to null
 
-        amount, token = parse_amount(op['amount'])
-        if token != 'SBD':
+        amount, token = parse_amount(op['amount'], None, chain)
+        if chain == 'mainnet' and token != 'SBD':
+            return # only care about SBD payments
+        elif chain == 'testnet' and token != 'TBD':
             return # only care about SBD payments
 
         url = op['memo']

--- a/hive/server/condenser_api/objects.py
+++ b/hive/server/condenser_api/objects.py
@@ -146,10 +146,15 @@ def _condenser_post_object(row, truncate_body=0):
 
     return post
 
-def _amount(amount, asset='SBD'):
+def _amount(amount, asset='SBD', chain='mainnet'):
     """Return a steem-style amount string given a (numeric, asset-str)."""
-    assert asset == 'SBD', 'unhandled asset %s' % asset
-    return "%.3f SBD" % amount
+    assert chain == 'mainnet' and asset == 'SBD', 'unhandled asset %s' % asset
+    assert chain == 'testnet' and asset == 'TBD', 'unhandled asset %s' % asset
+    
+    if chain == 'mainnet':
+        return "%.3f SBD" % amount
+    elif chain == 'testnet':
+        return "%.3f TBD" % amount
 
 def _hydrate_active_votes(vote_csv):
     """Convert minimal CSV representation into steemd-style object."""

--- a/hive/steem/http_client.py
+++ b/hive/steem/http_client.py
@@ -89,6 +89,7 @@ class HttpClient(object):
         get_order_book='condenser_api',
         get_feed_history='condenser_api',
         get_dynamic_global_properties='database_api',
+        get_config='database_api',
     )
 
     def __init__(self, nodes, **kwargs):

--- a/hive/utils/stats.py
+++ b/hive/utils/stats.py
@@ -83,6 +83,7 @@ class SteemStats(StatsAbstract):
     # Thresholds for critical call timing (ms)
     PAR_STEEMD = {
         'get_dynamic_global_properties': 20,
+        'get_config': 20,
         'get_block': 50,
         'get_blocks_batch': 5,
         'get_accounts': 3,

--- a/tests/steem/test_steem_client.py
+++ b/tests/steem/test_steem_client.py
@@ -54,6 +54,9 @@ def test_head_block(client):
 def test_last_irreversible(client):
     assert client.last_irreversible() > 23e6
 
+def test_is_mainnet(client):
+    assert not client.is_testnet()
+
 def test_gdgp_extended(client):
     ret = client.gdgp_extended()
     assert 'dgpo' in ret

--- a/tests/utils/test_utils_normalize.py
+++ b/tests/utils/test_utils_normalize.py
@@ -8,8 +8,8 @@ from hive.utils.normalize import (
     block_num,
     block_date,
     vests_amount,
-    steem_amount,
-    sbd_amount,
+    base_amount,
+    debt_amount,
     parse_amount,
     amount,
     legacy_amount,
@@ -41,17 +41,31 @@ def test_vests_amount():
     assert vests_amount('4.549292 VESTS') == Decimal('4.549292')
 
 def test_steem_amount():
-    assert steem_amount('1.234567 STEEM') == Decimal('1.234567')
+    assert base_amount('1.234567 STEEM', 'mainnet') == Decimal('1.234567')
+
+def test_tests_amount():
+    assert base_amount('1.234567 TESTS', 'testnet') == Decimal('1.234567')
 
 def test_sbd_amount():
-    assert sbd_amount('1.001 SBD') == Decimal('1.001')
+    assert debt_amount('1.001 SBD', 'mainnet') == Decimal('1.001')
+
+def test_tbs_amount():
+    assert debt_amount('1.001 TBD', 'testnet') == Decimal('1.001')
 
 def test_parse_amount():
     nai = [1231121, 6, '@@000000037']
     assert parse_amount(nai, 'VESTS') == Decimal('1.231121')
 
+def test_parse_mainnet_amount():
+    nai = [1231121, 6, '@@000000037']
+    assert parse_amount(nai, 'VESTS', 'mainnet') == Decimal('1.231121')
+
+def test_parse_testnet_amount():
+    nai = [1231121, 6, '@@000000037']
+    assert parse_amount(nai, 'VESTS', 'testnet') == Decimal('1.231121')
+
 def test_amount():
-    assert amount('3.432 FOO') == Decimal('3.432')
+    assert amount('3.432 FOO', 'mainnet') == Decimal('3.432')
 
 def test_legacy_amount():
     nai = [1231121, 6, '@@000000037']


### PR DESCRIPTION
This is my initial stab at adding testnet support to hivemind.  In order to try it out, you have to run a stable testnet.  Unfortunately, at the moment, the official testnet responds with `Unable to acquire database lock`.

So, I am testing with tintoy instead, which allows me to launch a tiny testnet with ~2,000 accounts.  To run:

```bash
docker run -d -p 8091:8091 inertia/tintoy:latest
# wait for it to load after < 10 minutes or so
hive sync --steemd_url http://localhost:8091
```

At this point, the problem appears to be some kind of "timeout" situation when trying to connect to `localhost:8091`.  I believe it's expecting SSL, but I don't see where it's getting that.

I'm using ephemeral ports in this example:

```
bucky:hivemind (testnet-support)$ hive sync --steemd-url http://localhost:32768
INFO:root:loaded configuration:
Command Line Args:   sync --steemd-url http://localhost:32768
Environment Variables:
  DATABASE_URL:      postgresql://localhost:5432/hive
Defaults:
  mode:              ['sync']
  --http-server-port:8080
  --max-workers:     4
  --max-batch:       50
  --trail-blocks:    2
  --sync-to-s3:      False
  --log-level:       INFO
  --test-disable-sync:False

INFO:hive.steem.http_client:using node: http://localhost:32768
INFO:hive.db.db_state:[INIT] Welcome to hive!
INFO:hive.steem.http_client:using node: http://localhost:32768
ERROR:hive.steem.http_client:get_config[1] failed in 30.0s. try 1. {'secs': 30.008, 'try': 1} - ReadTimeoutError("HTTPConnectionPool(host='localhost', port=32768): Read timed out. (read timeout=30)")
^C
```

Any suggestions?