### PR TITLE
Fix method name for db_head_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ hive server
 ```
 
 ```bash
-$ curl --data '{"jsonrpc":"2.0","id":0,"method":"db_head_state"}' http://localhost:8080
+$ curl --data '{"jsonrpc":"2.0","id":0,"method":"hive.db_head_state"}' http://localhost:8080
 {"jsonrpc": "2.0", "result": {"db_head_block": 19930795, "db_head_time": "2018-02-16 21:35:42", "db_head_age": 10}, "id": 0}
 ```
 


### PR DESCRIPTION
The actual method name is `hive.db_head_state` while the documentation mentions it as `db_head_state`.

```sh
# Earlier call result
$ curl --data '{"jsonrpc":"2.0","id":0,"method":"db_head_state"}' <your-host>
{"id": 0, "jsonrpc": "2.0", "error": {"code": -32601, "message": "Method not found", "data": "db_head_state"}}

# Fixed call result
$ curl --data '{"jsonrpc":"2.0","id":0,"method":"hive.db_head_state"}' <your-host>
{"result": {"db_head_block": 19439000, "db_head_age": 29504575, "db_head_time": "2018-01-30 19:09:21"}, "id": 0, "jsonrpc": "2.0"}
```