### PR TITLE
query planner nudge for comments-by-author sql

### DIFF
--- a/hive/server/condenser_api/cursor.py
+++ b/hive/server/condenser_api/cursor.py
@@ -303,12 +303,13 @@ async def pids_by_account_comments(db, account: str, start_permlink: str = '', l
 
         seek = "AND id <= :start_id"
 
+    # `depth` in ORDER BY is a no-op, but forces an ix3 index scan (see #189)
     sql = """
         SELECT id FROM hive_posts
          WHERE author = :account %s
            AND depth > 0
            AND is_deleted = '0'
-      ORDER BY id DESC
+      ORDER BY id, depth DESC
          LIMIT :limit
     """ % seek
 


### PR DESCRIPTION
fix #189

Before:
```
"Limit  (cost=0.57..948.61 rows=20 width=4) (actual time=23210.312..156553.376 rows=20 loops=1)"
"  Buffers: shared hit=1613950 read=345749 dirtied=1"
"  ->  Index Scan Backward using hive_posts_pkey on hive_posts  (cost=0.57..3489976.61 rows=73625 width=4) (actual time=23210.309..156553.359 rows=20 loops=1)"
"        Filter: ((NOT is_deleted) AND (depth > 0) AND ((author)::text = 'originalworks'::text))"
"        Rows Removed by Filter: 41795175"
"        Buffers: shared hit=1613950 read=345749 dirtied=1"
"Planning time: 0.454 ms"
"Execution time: 156553.409 ms"
```

After:
```
"Limit  (cost=4198.02..4198.07 rows=20 width=6) (actual time=58.901..58.912 rows=20 loops=1)"
"  Buffers: shared hit=513"
"  ->  Sort  (cost=4198.02..4359.65 rows=64653 width=6) (actual time=58.900..58.904 rows=20 loops=1)"
"        Sort Key: id, depth DESC"
"        Sort Method: top-N heapsort  Memory: 25kB"
"        Buffers: shared hit=513"
"        ->  Index Only Scan using hive_posts_ix3 on hive_posts  (cost=0.57..2477.63 rows=64653 width=6) (actual time=0.037..33.425 rows=96751 loops=1)"
"              Index Cond: ((author = 'originalworks'::text) AND (depth > 0))"
"              Heap Fetches: 0"
"              Buffers: shared hit=513"
"Planning time: 0.167 ms"
"Execution time: 58.940 ms"
```