### PR TITLE
Missing API in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ condenser_api.get_discussions_by_blog
 condenser_api.get_discussions_by_feed
 condenser_api.get_discussions_by_comments
 condenser_api.get_replies_by_last_update
+
+condenser_api.get_blog
+condenser_api.get_blog_entries
+condenser_api.get_discussions_by_author_before_date
 ```
 
 


### PR DESCRIPTION
Added 3 missing API to the documentation. They were present in the api-examples.md but not in the README.md:
condenser_api.get_blog
condenser_api.get_blog_entries
condenser_api.get_discussions_by_author_before_date

I tested them and they're indeed in hivemind.