### PR TITLE
Add missing comma to example JSON

### DIFF
--- a/docs/communities.md
+++ b/docs/communities.md
@@ -197,7 +197,7 @@ The standard format for `custom_json` ops:
 ["setRole", {
     "community": <community>,
     "account": <account>,
-    "role": admin|mod|member|none|muted
+    "role": admin|mod|member|none|muted,
     "notes": <comment>
 }]
 ```


### PR DESCRIPTION
I was creating myself a community when I noticed that a comma was missing.