### PR TITLE
indexer adjustments

### DIFF
--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -332,7 +332,16 @@ class CachedPost:
                     # fields blank. While it's best to not try to cache
                     # already-deleted posts, it can happen during missed
                     # post sweep and while using `trail_blocks` > 0.
-                    pass
+
+                    # monitor: post not found which should def. exist; see #173
+                    sql = """SELECT id, author, permlink, is_deleted
+                               FROM hive_posts WHERE id = :id"""
+                    row = DB.query_row(sql, id=pid)
+                    if level == 'insert' and not row['is_deleted']:
+                        log.warning("couldnt load post for %s: %s", level, row)
+                    else:
+                        log.info("couldnt load post for %s: %s", level, row)
+
                 cls._bump_last_id(pid)
 
             timer.batch_lap()

--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -384,8 +384,8 @@ class CachedPost:
 
         gap = next_id - last_id - 1
         if gap:
+            log.info("skipped %d ids %d -> %d", gap, last_id, next_id)
             cls._ensure_safe_gap(last_id, next_id)
-            log.warning("skipped %d posts %d -> %d", gap, last_id, next_id)
 
         cls._last_id = next_id
 

--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -382,26 +382,22 @@ class CachedPost:
         if next_id <= last_id:
             return
 
-        if next_id - last_id > 2:
+        gap = next_id - last_id - 1
+        if gap:
             cls._ensure_safe_gap(last_id, next_id)
-            if next_id - last_id > 4:
-                # gap of 2 is common due to deletions. report on larger gaps.
-                log.warning("skipping post ids %d -> %d", last_id, next_id)
+            log.warning("skipped %d posts %d -> %d", gap, last_id, next_id)
 
         cls._last_id = next_id
 
     @classmethod
     def _ensure_safe_gap(cls, last_id, next_id):
         """Paranoid check of important operating assumption."""
-        sql = """
-            SELECT COUNT(*) FROM hive_posts
-            WHERE id BETWEEN :x1 AND :x2 AND is_deleted = '0'
-        """
+        sql = """SELECT COUNT(*) FROM hive_posts
+                  WHERE id BETWEEN :x1 AND :x2 AND is_deleted = '0'"""
         missing_posts = DB.query_one(sql, x1=(last_id + 1), x2=(next_id - 1))
-        if not missing_posts:
-            return
-        raise Exception("found large cache gap: %d --> %d (%d)"
-                        % (last_id, next_id, missing_posts))
+        if missing_posts:
+            raise Exception("found cache gap: %d --> %d (%d)"
+                            % (last_id, next_id, missing_posts))
 
     @classmethod
     def _sql(cls, pid, post, level=None):

--- a/hive/indexer/custom_op.py
+++ b/hive/indexer/custom_op.py
@@ -24,7 +24,7 @@ def _get_auth(op):
     is always used and length 1. It may be that some ops will require
     `required_active_auths` in the future. For now, these are ignored.
     """
-    if op['required_active_auths']:
+    if op['required_auths']:
         log.warning("unexpected active auths: %s", op)
         return None
     if len(op['required_posting_auths']) != 1:

--- a/hive/indexer/custom_op.py
+++ b/hive/indexer/custom_op.py
@@ -17,6 +17,21 @@ DB = Db.instance()
 
 log = logging.getLogger(__name__)
 
+def _get_auth(op):
+    """get account name submitting a custom_json op.
+
+    Hive custom_json op processing requires `required_posting_auths`
+    is always used and length 1. It may be that some ops will require
+    `required_active_auths` in the future. For now, these are ignored.
+    """
+    if op['required_active_auths']:
+        log.warning("unexpected active auths: %s", op)
+        return None
+    if len(op['required_posting_auths']) != 1:
+        log.warning("unexpected auths: %s", op)
+        return None
+    return op['required_posting_auths'][0]
+
 class CustomOp:
     """Processes custom ops and dispatches updates."""
 
@@ -27,18 +42,11 @@ class CustomOp:
             if op['id'] not in ['follow', 'com.steemit.community']:
                 continue
 
-            # we assume `required_posting_auths` is always used and length 1.
-            # it may be that some ops require `required_active_auths` instead.
-            # (e.g. if we use that route for admin action of acct creation)
-            # if op['required_active_auths']:
-            #    log.warning("unexpected active auths: %s" % op)
-            if len(op['required_posting_auths']) != 1:
-                log.warning("unexpected auths: %s", op)
+            account = _get_auth(op)
+            if not account:
                 continue
 
-            account = op['required_posting_auths'][0]
             op_json = load_json_key(op, 'json')
-
             if op['id'] == 'follow':
                 if block_num < 6000000 and not isinstance(op_json, list):
                     op_json = ['follow', op_json]  # legacy compat

--- a/hive/indexer/sync.py
+++ b/hive/indexer/sync.py
@@ -39,8 +39,9 @@ class Sync:
         # ensure db schema up to date, check app status
         DbState.initialize()
 
-        # prefetch id->name memory map
+        # prefetch id->name and id->rank memory maps
         Accounts.load_ids()
+        Accounts.fetch_ranks()
 
         if DbState.is_initial_sync():
             # resume initial sync
@@ -189,8 +190,8 @@ class Sync:
                      cnt['insert'], cnt['update'], cnt['payout'], cnt['upvote'],
                      cnt['recount'], accts, follows, ms, ' SLOW' if ms > 1000 else '')
 
-            #if num % 1200 == 0: #1hr
-            #    Accounts.update_ranks() #144
+            if num % 1200 == 0: #1hr
+                Accounts.fetch_ranks()
             if num % 100 == 0: #5min
                 Accounts.dirty_oldest(500)
                 Accounts.flush(steemd, trx=True)

--- a/hive/steem/block/stream.py
+++ b/hive/steem/block/stream.py
@@ -82,7 +82,7 @@ class BlockStream:
 
         while self._gap_ok(curr, head):
             head = schedule.wait_for_block(curr)
-            block = self._client.get_block(curr)
+            block = self._client.get_block(curr, strict=False)
             schedule.check_block(curr, block)
 
             if not block:

--- a/hive/steem/client.py
+++ b/hive/steem/client.py
@@ -46,14 +46,19 @@ class SteemClient:
             assert 'author' in post, "invalid post: %s" % post
         return posts
 
-    def get_block(self, num):
+    def get_block(self, num, strict=True):
         """Fetches a single block.
 
         If the result does not contain a `block` key, it's assumed
         this block does not yet exist and None is returned.
         """
         result = self.__exec('get_block', {'block_num': num})
-        return result['block'] if 'block' in result else None
+        if 'block' in result:
+            return result['block']
+        elif strict:
+            raise Exception('block %d not available' % num)
+        else:
+            return None
 
     def stream_blocks(self, start_from, trail_blocks=0, max_gap=100):
         """Stream blocks. Returns a generator."""


### PR DESCRIPTION
- when writing cached post, use authoritative `category` from `hive_posts` (refs. #205)
- maintain `hive_accounts.rank` field (close #144)
- tidy custom_json auth read
- monitor #173 condition: missing cache entry
- make gap check more strict
- default get_block to strict