### PR TITLE
fix cache issue, cache dgpo

### DIFF
--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -171,11 +171,12 @@ class CachedPost:
             summary = ', '.join(summary) if summary else 'none'
             log.info("[PREP] posts cache process: %s", summary)
 
-        cls._update_batch(steem, tuples, trx, full_total=full_total)
         for url, _, _ in tuples:
             del cls._queue[url]
             if url in cls._ids:
                 del cls._ids[url]
+
+        cls._update_batch(steem, tuples, trx, full_total=full_total)
 
         return counts
 

--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -173,10 +173,12 @@ class CachedPost:
 
         for url, _, _ in tuples:
             del cls._queue[url]
-            if url in cls._ids:
-                del cls._ids[url]
 
         cls._update_batch(steem, tuples, trx, full_total=full_total)
+
+        for url, _, _ in tuples:
+            if url not in cls._queue and url in cls._ids:
+                del cls._ids[url]
 
         return counts
 

--- a/hive/indexer/cached_post.py
+++ b/hive/indexer/cached_post.py
@@ -111,8 +111,10 @@ class CachedPost:
 
         # if it was queued for a write, remove it
         url = author+'/'+permlink
+        log.warning("deleting %s", url)
         if url in cls._queue:
             del cls._queue[url]
+            log.warning("deleted %s", url)
             if url in cls._ids:
                 del cls._ids[url]
 
@@ -151,6 +153,7 @@ class CachedPost:
             'author': author,
             'permlink': permlink}))
         cls.update(author, permlink, post_id)
+        log.warning("undeleted %s/%s", author, permlink)
 
     @classmethod
     def flush(cls, steem, trx=False, spread=1, full_total=None):

--- a/hive/server/condenser_api/get_state.py
+++ b/hive/server/condenser_api/get_state.py
@@ -4,6 +4,7 @@
 import logging
 from collections import OrderedDict
 import ujson as json
+from aiocache import cached
 
 from hive.utils.normalize import legacy_amount
 from hive.server.common.mutes import Mutes
@@ -278,11 +279,13 @@ async def _load_discussion(db, author, permlink):
     # return all nodes keyed by ref
     return {refs[pid]: post for pid, post in posts.items()}
 
+@cached(ttl=1800, timeout=1200)
 async def _get_feed_price(db):
     """Get a steemd-style ratio object representing feed price."""
     price = await db.query_one("SELECT usd_per_steem FROM hive_state")
     return {"base": "%.3f SBD" % price, "quote": "1.000 STEEM"}
 
+@cached(ttl=1800, timeout=1200)
 async def _get_props_lite(db):
     """Return a minimal version of get_dynamic_global_properties data."""
     raw = json.loads(await db.query_one("SELECT dgpo FROM hive_state"))


### PR DESCRIPTION
 - change to `hive/indexer/cached_post.py` now removes pending items from the queue prior to processing so that deferred items are tracked properly. #244
 - adds 30min cache to dgpo and steem price fetch