### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Build flags
 
 Plugins
 
- - Required: `reputation reputation_api database_api condenser_api block_api`
- - Not required: `follow*`, `tags*`, `market_history`, `account_history`, `witness`
+ - Required: `reputation reputation_api database_api condenser_api block_api market_history_api`
+ - Not required: `follow*`, `tags*`, `account_history`, `witness`
 
 
 ### Postgres Performance


### PR DESCRIPTION
The Hivemind gives a warning info:
```
WARNING:hive.steem.http_client:get_order_book[1] failed in 0.0s. try 90. {'jussi-id': None, 'secs': 0.002, 'try': 90} - RPCError('assert_exception[-32003]: `Assert Exception:_market_history_api: market_history_api_plugin not enabled.`  in condenser_api.get_order_book([1])',)
```
So we need add the `market_history_api` into the plugin list.