### PR TITLE
Fix TypeError in BlockQueue.push() #341

### DIFF
--- a/hive/steem/block/stream.py
+++ b/hive/steem/block/stream.py
@@ -39,7 +39,7 @@ class BlockQueue:
             if self._queue: # if using max_size>0, fork might be in buffer only
                 buff = self.size()
                 alert = "NOTIFYALERT " if buff < self._max_size else ""
-                raise MicroForkException("%squeue:%d %s" % (alert, fork, buff))
+                raise MicroForkException(f"{alert}queue:{buff} {fork}")
             raise ForkException("NOTIFYALERT fork " + fork)
 
         self._prev = next_hash

--- a/hive/steem/block/stream.py
+++ b/hive/steem/block/stream.py
@@ -35,7 +35,7 @@ class BlockQueue:
         next_hash = block['block_id']
         next_prev = block['previous']
         if self._prev != next_prev:
-            fork = "%s--> %s->%s" % (self._prev, next_prev, next_hash)
+            fork = f"{self._prev}--> {next_prev}->{next_hash}"
             if self._queue: # if using max_size>0, fork might be in buffer only
                 buff = self.size()
                 alert = "NOTIFYALERT " if buff < self._max_size else ""


### PR DESCRIPTION
The TypeError in BlockQueue.push() leads to restart sync process.