### PR TITLE
add an optional start parameter to force recounting follower/following

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ docker logs -f hivemind
 | `MAX_WORKERS`            | `--max-workers`      | 4       |
 | `TRAIL_BLOCKS`           | `--trail-blocks`     | 2       |
 | `RECOMMEND_COMMUNITIES`  | `--recommend-communities` | hive-108451,hive-172186,hive-187187   |
+| `FORCE_FOLLOW_RECOUNT`   | `--force-follow-recount`  | False   |
 
 Precedence: CLI over ENV over hive.conf. Check `hive --help` for details.
 

--- a/hive/conf.py
+++ b/hive/conf.py
@@ -57,6 +57,9 @@ class Conf():
         # txid collector
         add('--txid-collector', type=strtobool, env_var='TXID_COLLECTOR', help='alternative collect txid to block number', default=False)
 
+        # force follow recount
+        add('--force-follow-recount', type=strtobool, env_var='FORCE_FOLLOW_RECOUNT', help='force recount of follow relationships at startup', default=False)
+
         # needed for e.g. tests - other args may be present
         args = (parser.parse_args() if strict
                 else parser.parse_known_args()[0])

--- a/hive/indexer/sync.py
+++ b/hive/indexer/sync.py
@@ -67,6 +67,11 @@ class Sync:
             # perform cleanup if process did not exit cleanly
             CachedPost.recover_missing_posts(self._steem)
 
+            if self._conf.get('force_follow_recount'):
+                # force recount of all follows
+                log.info("[SYNC] Force recount of all follows")
+                Follow.force_recount()
+
         #audit_cache_missing(self._db, self._steem)
         #audit_cache_deleted(self._db)
 


### PR DESCRIPTION
For reasons that are still unclear, there are differences in follower counts between nodes (see issue #350).

This PR adds a new start parameter `--force-follow-recount`. With this parameter, a recount of all follow relationships can be forced when starting hive.