### PR TITLE
perf: optimize slow queries for trending/feed/community APIs

### DIFF
--- a/hive/db/db_state.py
+++ b/hive/db/db_state.py
@@ -446,6 +446,49 @@ class DbState:
             log.info("[HIVE] hive_posts_cache_ix31 dropped (recovered ~2GB)")
             cls._set_ver(26)
 
+        if cls._ver == 26:
+            # Performance optimization: Add indexes for slow queries
+            # Reference: beta-hivemind-slow-query-analysis.md
+            log.info("[HIVE] Creating slow query optimization indexes...")
+
+            # 1. hive_posts_cache_temp depth+trending index
+            # Optimizes trending/new queries with depth=0 filter
+            cls.db().query("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS hive_posts_cache_temp_ix6b
+                ON hive_posts_cache_temp (depth, sc_trend DESC, post_id)
+                WHERE is_paidout = '0' AND depth = 0
+            """)
+
+            # 2. hive_posts_cache_temp community+depth+trending index
+            # Optimizes community trending queries
+            cls.db().query("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS hive_posts_cache_temp_ix30b
+                ON hive_posts_cache_temp (community_id, depth, sc_trend DESC, post_id)
+                WHERE community_id IS NOT NULL AND is_grayed = '0' AND depth = 0
+            """)
+
+            # 3. hive_feed_cache account+created index (if not exists from v23)
+            # Optimizes feed/blog ORDER BY created_at DESC queries
+            cls.db().query("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_feed_cache_account_created_desc
+                ON hive_feed_cache (account_id, created_at DESC, post_id)
+            """)
+
+            # 4. hive_reblogs post+account index
+            # Optimizes NOT EXISTS subquery in pids_by_blog
+            cls.db().query("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_reblogs_post_account
+                ON hive_reblogs (post_id, account)
+            """)
+
+            # Update statistics after creating indexes
+            cls.db().query("ANALYZE hive_posts_cache_temp")
+            cls.db().query("ANALYZE hive_feed_cache")
+            cls.db().query("ANALYZE hive_reblogs")
+
+            log.info("[HIVE] Slow query optimization indexes created")
+            cls._set_ver(27)
+
         reset_autovac(cls.db())
 
         log.info("[HIVE] db version: %d", cls._ver)

--- a/hive/db/schema.py
+++ b/hive/db/schema.py
@@ -10,7 +10,7 @@ from sqlalchemy.types import BOOLEAN
 
 #pylint: disable=line-too-long, too-many-lines, bad-whitespace
 
-DB_VERSION = 26
+DB_VERSION = 27
 
 def build_metadata():
     """Build schema def with SqlAlchemy"""
@@ -300,6 +300,13 @@ def build_temp_cache_metadata(metadata=None):
         sa.Index('hive_posts_cache_temp_ix30', 'community_id', 'sc_trend', 'post_id',
                  postgresql_where=sql_text("community_id IS NOT NULL AND is_grayed = '0' AND depth = 0")),
         sa.Index('hive_posts_cache_temp_created', 'created_at'),
+        # Slow query optimization indexes (added in v27)
+        # Optimizes trending queries with depth=0 filter
+        sa.Index('hive_posts_cache_temp_ix6b', 'depth', 'sc_trend', 'post_id',
+                 postgresql_where=sql_text("is_paidout = '0' AND depth = 0")),
+        # Optimizes community trending queries
+        sa.Index('hive_posts_cache_temp_ix30b', 'community_id', 'depth', 'sc_trend', 'post_id',
+                 postgresql_where=sql_text("community_id IS NOT NULL AND is_grayed = '0' AND depth = 0")),
     )
     return metadata
 

--- a/hive/server/bridge_api/cursor.py
+++ b/hive/server/bridge_api/cursor.py
@@ -168,9 +168,11 @@ async def pids_by_community(db, ids, sort, seek_id, limit):
     #sql = "SELECT post_id FROM hive_posts_status WHERE list_type = '1'"
     #where.append("post_id NOT IN (%s)" % sql)
 
-    # hide author
-    sql = "SELECT author FROM hive_posts_status WHERE list_type = '3'"
-    where.append("author NOT IN (%s)" % sql)
+    # hide author (using NOT EXISTS for better performance than NOT IN)
+    where.append("""NOT EXISTS (
+        SELECT 1 FROM hive_posts_status s
+        WHERE s.list_type = '3' AND s.author = %s.author
+    )""" % table)
 
     # build
     sql = ("""SELECT post_id FROM %s WHERE %s
@@ -230,9 +232,12 @@ async def pids_by_category(db, tag, sort, last_id, limit):
     #sql = "SELECT post_id FROM hive_posts_status WHERE list_type = '1'"
     #where.append("post_id NOT IN (%s)" % sql)
 
-    # hide author
-    sql = "SELECT author FROM hive_posts_status WHERE list_type = '3'"
-    where.append("author NOT IN (%s)" % sql)
+    # hide author (using NOT EXISTS for better performance than NOT IN)
+    table = CacheRouter.get_table(sort)
+    where.append("""NOT EXISTS (
+        SELECT 1 FROM hive_posts_status s
+        WHERE s.list_type = '3' AND s.author = %s.author
+    )""" % table)
 
     sql = ("""SELECT post_id FROM %s WHERE %s
               ORDER BY %s DESC, post_id LIMIT :limit


### PR DESCRIPTION
Based on beta-hivemind-slow-query-analysis.md report:

Database Indexes (v26 -> v27):
- Add hive_posts_cache_temp_ix6b: depth+sc_trend index for trending queries
- Add hive_posts_cache_temp_ix30b: community+depth+sc_trend index for community queries
- Add idx_feed_cache_account_created_desc: optimize feed/blog ORDER BY
- Add idx_reblogs_post_account: optimize NOT EXISTS subquery

Query Optimization:
- Replace 'author NOT IN (subquery)' with NOT EXISTS in:
  - pids_by_community()
  - pids_by_category()
- NOT EXISTS performs better than NOT IN with PostgreSQL

Expected improvement:
- Trending queries: 281ms -> ~20ms (14x faster)
- Feed queries: 30ms -> ~5ms (6x faster)
- Community queries: 23ms -> ~3ms (7x faster)
- Total CPU: ~13.6% -> ~2%