### PR TITLE
fix: migrate get_dynamic_global_properties from database_api to condenser_api

### DIFF
--- a/hive/steem/http_client.py
+++ b/hive/steem/http_client.py
@@ -88,7 +88,7 @@ class HttpClient(object):
         get_accounts='condenser_api',
         get_order_book='condenser_api',
         get_feed_history='condenser_api',
-        get_dynamic_global_properties='database_api',
+        get_dynamic_global_properties='condenser_api',
     )
 
     def __init__(self, nodes, **kwargs):


### PR DESCRIPTION
## Problem

`get_dynamic_global_properties` in `hive/steem/http_client.py` still maps to `database_api`, while all other methods in `METHOD_API` already use `condenser_api`.

This causes a **Bad Cast** error when the request reaches steemd, because:

1. `_rpc_body()` generates `params={}` for `database_api` methods (line 78)
2. jussi Go `translateToAppbase` rewrites `database_api.*` → `condenser_api.*` but does not normalize `params` format
3. steemd appbase requires `params=[]` (array) for `condenser_api` methods
4. Result: `Bad Cast: Invalid cast from object_type to Array`

## Fix

Change the `METHOD_API` mapping:
```python
# Before
get_dynamic_global_properties='database_api',

# After
get_dynamic_global_properties='condenser_api',
```

`_rpc_body()` already has the logic to use `[]` for `condenser_api` methods (line 78: `args = [] if 'condenser_api' in method else {}`), so this one-line change fixes both the namespace and the params format.

## Context

- `database_api` is a low-level steemd plugin API being phased out
- `condenser_api` is the public-facing high-level API that wraps `database_api`, `follow_api`, `tags_api`
- jussi (both Go and Python) already translates all `database_api.*` calls to `condenser_api.*` via `translateToAppbase`
- hivemind only serves `condenser_api` (asserts `api == 'condenser_api'` in `call.py`)
- This was the **last remaining `database_api` usage** in hivemind's HTTP client

## Testing

Verified against `api.steemit.com`:
```bash
# database_api + object params → Bad Cast ❌
curl -s -X POST https://api.steemit.com \
  -d '{"jsonrpc":"2.0","method":"database_api.get_dynamic_global_properties","params":{},"id":1}' \
  -H 'Content-Type: application/json'

# condenser_api + array params → Success ✅
curl -s -X POST https://api.steemit.com \
  -d '{"jsonrpc":"2.0","method":"condenser_api.get_dynamic_global_properties","params":[],"id":1}' \
  -H 'Content-Type: application/json'
```