### PR TITLE
perf: mitigate slow follow/tag/rank queries (2026-07-12 outage)

### DIFF
--- a/hive/db/db_state.py
+++ b/hive/db/db_state.py
@@ -504,6 +504,27 @@ class DbState:
             log.info("[HIVE] hive_notifs_dst_post_type_idx index created")
             cls._set_ver(28)
 
+        if cls._ver == 28:
+            # Performance: symmetric partial index for get_followers + drop dup indexes
+            # get_followers queries `WHERE following = :id ... ORDER BY created_at DESC`
+            # but only had idx_follows_follower_state_created_desc (follower-led, serves
+            # get_following). Add a following-led counterpart so the planner can satisfy
+            # get_followers without falling back to the full-ASC ix5a + cross-value sort.
+            # Also drop hive_follows_5a/5b: legacy v9 duplicates of ix5a/ix5b (identical
+            # columns), pure write-amplification burden, never managed by _disableable_indexes.
+            log.info("[HIVE] Creating idx_follows_following_state_created_desc index...")
+            cls.db().query("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_follows_following_state_created_desc
+                ON hive_follows (following, state, created_at DESC, follower)
+                WHERE state IN (1,3)
+            """)
+            log.info("[HIVE] Dropping duplicate hive_follows_5a/5b indexes...")
+            cls.db().query("DROP INDEX CONCURRENTLY IF EXISTS hive_follows_5a")
+            cls.db().query("DROP INDEX CONCURRENTLY IF EXISTS hive_follows_5b")
+            cls.db().query("ANALYZE hive_follows")
+            log.info("[HIVE] hive_follows index optimization complete")
+            cls._set_ver(29)
+
         reset_autovac(cls.db())
 
         log.info("[HIVE] db version: %d", cls._ver)

--- a/hive/db/schema.py
+++ b/hive/db/schema.py
@@ -10,7 +10,7 @@ from sqlalchemy.types import BOOLEAN
 
 #pylint: disable=line-too-long, too-many-lines, bad-whitespace
 
-DB_VERSION = 28
+DB_VERSION = 29
 
 def build_metadata():
     """Build schema def with SqlAlchemy"""
@@ -112,7 +112,10 @@ def build_metadata():
         sa.Index('hive_follows_ix5a', 'following', 'state', 'created_at', 'follower'),
         sa.Index('hive_follows_ix5b', 'follower', 'state', 'created_at', 'following'),
         # Note: idx_follows_follower_following_state and idx_follows_follower_state_created_desc
-        # are created via migration (v23) because they use DESC and WHERE clauses
+        # are created via migration (v23) because they use DESC and WHERE clauses.
+        # v29: idx_follows_following_state_created_desc added via migration (symmetric
+        #      to idx_follows_follower_state_created_desc, serving get_followers).
+        # v29: hive_follows_5a/5b (v9 migration duplicates of ix5a/ix5b) dropped.
     )
 
     sa.Table(

--- a/hive/indexer/sync.py
+++ b/hive/indexer/sync.py
@@ -219,8 +219,13 @@ class Sync:
             if num % 1200 == 0: #1hr
                 log.warning("head block %d @ %s", num, block['timestamp'])
                 log.info("[LIVE] hourly stats")
-                Accounts.fetch_ranks()
                 #Community.recalc_pending_payouts()
+            if num % 7200 == 0: #6hr
+                # Rank is an approximate score used for notification buckets; a 6h
+                # stale window is acceptable. Run less often than the previous 1h
+                # cadence to avoid the full-table ORDER BY vote_weight DESC (~12s,
+                # million-scale) competing for RDS IOPS with API queries.
+                Accounts.fetch_ranks()
             if num % 200 == 0: #10min
                 Community.recalc_pending_payouts()
             if num % 100 == 0: #5min

--- a/hive/server/bridge_api/cursor.py
+++ b/hive/server/bridge_api/cursor.py
@@ -243,7 +243,18 @@ async def pids_by_category(db, tag, sort, last_id, limit):
               ORDER BY %s DESC, post_id LIMIT :limit
               """ % (table, ' AND '.join(where), field))
 
-    return await db.query_col(sql, tag=tag, last_id=last_id, limit=limit)
+    # Generate cache key with all parameters that affect the result
+    cache_key_parts = [
+        'pids_by_category',
+        str(sort),
+        str(tag),
+        str(last_id),
+        str(limit)
+    ]
+    cache_key = '_'.join(cache_key_parts)
+
+    return await db.query_col(sql, tag=tag, last_id=last_id, limit=limit,
+                              cache_key=cache_key, cache_ttl=60)
 
 
 async def _subscribed(db, account_id):

--- a/hive/server/condenser_api/cursor.py
+++ b/hive/server/condenser_api/cursor.py
@@ -304,7 +304,19 @@ async def pids_by_query(db, sort, start_author, start_permlink, limit, tag):
     sql = ("SELECT post_id FROM %s WHERE %s ORDER BY %s DESC LIMIT :limit"
            % (table, ' AND '.join(where), field))
 
-    return await db.query_col(sql, tag=tag, start_id=start_id, limit=limit)
+    # Generate cache key with all parameters that affect the result
+    cache_key_parts = [
+        'pids_by_query',
+        str(sort),
+        str(tag),
+        str(start_author),
+        str(start_permlink),
+        str(limit)
+    ]
+    cache_key = '_'.join(cache_key_parts)
+
+    return await db.query_col(sql, tag=tag, start_id=start_id, limit=limit,
+                              cache_key=cache_key, cache_ttl=60)
 
 
 async def pids_by_blog(db, account: str, start_author: str = '',

--- a/hive/server/condenser_api/cursor.py
+++ b/hive/server/condenser_api/cursor.py
@@ -55,10 +55,12 @@ async def get_followers(db, account: str, start: str, follow_type: str, limit: i
     """Get a list of accounts following a given account."""
     account_id = await _get_account_id(db, account)
     start_id = await _get_account_id(db, start) if start else None
-    # Hardcode state IN (...) so the planner can match the partial index
-    # idx_follows_following_state_created_desc (WHERE state IN (1,3)).
-    # A parameterized `state IN :state` tuple cannot be proven to satisfy the
-    # partial-index predicate at plan time.
+    # Hardcode the state filter (instead of a parameterized `state IN :state`
+    # tuple) so the normal branch (state IN (1,3)) can match the partial index
+    # idx_follows_following_state_created_desc. The ignore branch (state IN
+    # (2,3)) cannot match that partial index (predicate is state IN (1,3)) and
+    # falls back to ix5a; hardcoding still beats a tuple bind via better
+    # cardinality estimates.
     state_clause = ("AND hf.state IN (2, 3)"
                     if follow_type == 'ignore'
                     else "AND hf.state IN (1, 3)")
@@ -87,7 +89,7 @@ async def get_followers(db, account: str, start: str, follow_type: str, limit: i
         'get_followers',
         str(account_id),
         follow_type or 'blog',
-        str(start_id) if start_id else '',
+        'none' if start_id is None else str(start_id),
         str(limit)
     ]
     cache_key = '_'.join(cache_key_parts)
@@ -100,8 +102,11 @@ async def get_followers(db, account: str, start: str, follow_type: str, limit: i
 async def get_followers_by_page(db, account: str, page: int, page_size: int, follow_type: str):
     """Get a list of accounts following a given account."""
     account_id = await _get_account_id(db, account)
-    # Hardcode state IN (...) so the planner can match the partial index
-    # idx_follows_following_state_created_desc (WHERE state IN (1,3)).
+    # Hardcode the state filter so the normal branch (state IN (1,3)) can match
+    # the partial index idx_follows_following_state_created_desc. The ignore
+    # branch (state IN (2,3)) cannot match that partial index (predicate is
+    # state IN (1,3)) and falls back to ix5a; hardcoding still beats a tuple
+    # bind via better cardinality estimates.
     state_clause = ("AND hf.state IN (2, 3)"
                     if follow_type == 'ignore'
                     else "AND hf.state IN (1, 3)")
@@ -136,8 +141,11 @@ async def get_following(db, account: str, start: str, follow_type: str, limit: i
     """Get a list of accounts followed by a given account."""
     account_id = await _get_account_id(db, account)
     start_id = await _get_account_id(db, start) if start else None
-    # Hardcode state IN (...) so the planner can match the partial index
-    # idx_follows_follower_state_created_desc (WHERE state IN (1,3)).
+    # Hardcode the state filter so the normal branch (state IN (1,3)) can match
+    # the partial index idx_follows_follower_state_created_desc. The ignore
+    # branch (state IN (2,3)) cannot match that partial index (predicate is
+    # state IN (1,3)) and falls back to ix5b; hardcoding still beats a tuple
+    # bind via better cardinality estimates.
     state_clause = ("AND hf.state IN (2, 3)"
                     if follow_type == 'ignore'
                     else "AND hf.state IN (1, 3)")
@@ -166,7 +174,7 @@ async def get_following(db, account: str, start: str, follow_type: str, limit: i
         'get_following',
         str(account_id),
         follow_type or 'blog',
-        str(start_id) if start_id else '',
+        'none' if start_id is None else str(start_id),
         str(limit)
     ]
     cache_key = '_'.join(cache_key_parts)
@@ -179,8 +187,11 @@ async def get_following(db, account: str, start: str, follow_type: str, limit: i
 async def get_following_by_page(db, account: str, page: int, page_size: int, follow_type: str):
     """Get a list of accounts followed by a given account."""
     account_id = await _get_account_id(db, account)
-    # Hardcode state IN (...) so the planner can match the partial index
-    # idx_follows_follower_state_created_desc (WHERE state IN (1,3)).
+    # Hardcode the state filter so the normal branch (state IN (1,3)) can match
+    # the partial index idx_follows_follower_state_created_desc. The ignore
+    # branch (state IN (2,3)) cannot match that partial index (predicate is
+    # state IN (1,3)) and falls back to ix5b; hardcoding still beats a tuple
+    # bind via better cardinality estimates.
     state_clause = ("AND hf.state IN (2, 3)"
                     if follow_type == 'ignore'
                     else "AND hf.state IN (1, 3)")

--- a/hive/server/condenser_api/cursor.py
+++ b/hive/server/condenser_api/cursor.py
@@ -55,7 +55,13 @@ async def get_followers(db, account: str, start: str, follow_type: str, limit: i
     """Get a list of accounts following a given account."""
     account_id = await _get_account_id(db, account)
     start_id = await _get_account_id(db, start) if start else None
-    state = (2,3) if follow_type == 'ignore' else (1,3)
+    # Hardcode state IN (...) so the planner can match the partial index
+    # idx_follows_following_state_created_desc (WHERE state IN (1,3)).
+    # A parameterized `state IN :state` tuple cannot be proven to satisfy the
+    # partial-index predicate at plan time.
+    state_clause = ("AND hf.state IN (2, 3)"
+                    if follow_type == 'ignore'
+                    else "AND hf.state IN (1, 3)")
 
     seek = ''
     if start_id:
@@ -71,19 +77,34 @@ async def get_followers(db, account: str, start: str, follow_type: str, limit: i
         FROM hive_follows hf
         INNER JOIN hive_accounts ha ON hf.follower = ha.id
         WHERE hf.following = :account_id
-          AND hf.state IN :state %s
+          %s %s
         ORDER BY hf.created_at DESC
         LIMIT :limit
-    """ % seek
+    """ % (state_clause, seek)
+
+    # Generate cache key with all parameters that affect the result
+    cache_key_parts = [
+        'get_followers',
+        str(account_id),
+        follow_type or 'blog',
+        str(start_id) if start_id else '',
+        str(limit)
+    ]
+    cache_key = '_'.join(cache_key_parts)
 
     return await db.query_all(sql, account_id=account_id, start_id=start_id,
-                              state=state, limit=limit)
+                              limit=limit,
+                              cache_key=cache_key, cache_ttl=30)
 
 
 async def get_followers_by_page(db, account: str, page: int, page_size: int, follow_type: str):
     """Get a list of accounts following a given account."""
     account_id = await _get_account_id(db, account)
-    state = (2,3) if follow_type == 'ignore' else (1,3)
+    # Hardcode state IN (...) so the planner can match the partial index
+    # idx_follows_following_state_created_desc (WHERE state IN (1,3)).
+    state_clause = ("AND hf.state IN (2, 3)"
+                    if follow_type == 'ignore'
+                    else "AND hf.state IN (1, 3)")
 
     # Optimized: Use INNER JOIN instead of LEFT JOIN for better performance
     # This assumes data integrity (all follower IDs exist in hive_accounts)
@@ -92,19 +113,34 @@ async def get_followers_by_page(db, account: str, page: int, page_size: int, fol
         FROM hive_follows hf
         INNER JOIN hive_accounts ha ON hf.follower = ha.id
         WHERE hf.following = :account_id
-          AND hf.state IN :state
+          %s
         ORDER BY hf.created_at DESC
         LIMIT :limit OFFSET :offset
-    """
+    """ % state_clause
+
+    # Generate cache key with all parameters that affect the result
+    cache_key_parts = [
+        'get_followers_by_page',
+        str(account_id),
+        follow_type or 'blog',
+        str(page),
+        str(page_size)
+    ]
+    cache_key = '_'.join(cache_key_parts)
 
     return await db.query_all(sql, account_id=account_id,
-                              state=state, limit=page_size, offset=page*page_size)
+                              limit=page_size, offset=page*page_size,
+                              cache_key=cache_key, cache_ttl=30)
 
 async def get_following(db, account: str, start: str, follow_type: str, limit: int):
     """Get a list of accounts followed by a given account."""
     account_id = await _get_account_id(db, account)
     start_id = await _get_account_id(db, start) if start else None
-    state = (2, 3) if follow_type == 'ignore' else (1, 3)
+    # Hardcode state IN (...) so the planner can match the partial index
+    # idx_follows_follower_state_created_desc (WHERE state IN (1,3)).
+    state_clause = ("AND hf.state IN (2, 3)"
+                    if follow_type == 'ignore'
+                    else "AND hf.state IN (1, 3)")
 
     seek = ''
     if start_id:
@@ -120,10 +156,10 @@ async def get_following(db, account: str, start: str, follow_type: str, limit: i
         FROM hive_follows hf
         INNER JOIN hive_accounts ha ON hf.following = ha.id
         WHERE hf.follower = :account_id
-          AND hf.state IN :state %s
+          %s %s
         ORDER BY hf.created_at DESC
         LIMIT :limit
-    """ % seek
+    """ % (state_clause, seek)
 
     # Generate cache key with all parameters that affect the result
     cache_key_parts = [
@@ -136,26 +172,46 @@ async def get_following(db, account: str, start: str, follow_type: str, limit: i
     cache_key = '_'.join(cache_key_parts)
 
     return await db.query_all(sql, account_id=account_id, start_id=start_id,
-                              state=state, limit=limit,
+                              limit=limit,
                               cache_key=cache_key, cache_ttl=30)
 
 
 async def get_following_by_page(db, account: str, page: int, page_size: int, follow_type: str):
     """Get a list of accounts followed by a given account."""
     account_id = await _get_account_id(db, account)
-    state = (2, 3) if follow_type == 'ignore' else (1, 3)
+    # Hardcode state IN (...) so the planner can match the partial index
+    # idx_follows_follower_state_created_desc (WHERE state IN (1,3)).
+    state_clause = ("AND hf.state IN (2, 3)"
+                    if follow_type == 'ignore'
+                    else "AND hf.state IN (1, 3)")
 
+    # Optimized: Use INNER JOIN instead of LEFT JOIN for better performance.
+    # This aligns with the other three follow* functions, which were migrated
+    # to INNER JOIN (3274329, 67c6d5e); this function was missed at the time.
+    # Assumes data integrity (all following IDs exist in hive_accounts).
     sql = """
-        SELECT name,reputation,state FROM hive_follows hf
-     LEFT JOIN hive_accounts ON hf.following = id
-         WHERE hf.follower = :account_id
-           AND state IN :state
-      ORDER BY hf.created_at DESC
-         LIMIT :limit OFFSET :offset
-    """
+        SELECT ha.name, ha.reputation, hf.state
+        FROM hive_follows hf
+        INNER JOIN hive_accounts ha ON hf.following = ha.id
+        WHERE hf.follower = :account_id
+          %s
+        ORDER BY hf.created_at DESC
+        LIMIT :limit OFFSET :offset
+    """ % state_clause
+
+    # Generate cache key with all parameters that affect the result
+    cache_key_parts = [
+        'get_following_by_page',
+        str(account_id),
+        follow_type or 'blog',
+        str(page),
+        str(page_size)
+    ]
+    cache_key = '_'.join(cache_key_parts)
 
     return await db.query_all(sql, account_id=account_id,
-                              state=state, limit=page_size, offset=page*page_size)
+                              limit=page_size, offset=page*page_size,
+                              cache_key=cache_key, cache_ttl=30)
 
 
 async def get_follow_counts(db, account: str):

--- a/hive/server/condenser_api/cursor.py
+++ b/hive/server/condenser_api/cursor.py
@@ -93,10 +93,14 @@ async def get_followers(db, account: str, start: str, follow_type: str, limit: i
         str(limit)
     ]
     cache_key = '_'.join(cache_key_parts)
+    # ignore (muted) relationships change rarely; use a longer TTL to avoid
+    # cache churn on the slow ix5a fallback path (no partial index for state
+    # IN (2,3)). Normal blog follows stay at 30s.
+    cache_ttl = 300 if follow_type == 'ignore' else 30
 
     return await db.query_all(sql, account_id=account_id, start_id=start_id,
                               limit=limit,
-                              cache_key=cache_key, cache_ttl=30)
+                              cache_key=cache_key, cache_ttl=cache_ttl)
 
 
 async def get_followers_by_page(db, account: str, page: int, page_size: int, follow_type: str):
@@ -132,10 +136,11 @@ async def get_followers_by_page(db, account: str, page: int, page_size: int, fol
         str(page_size)
     ]
     cache_key = '_'.join(cache_key_parts)
+    cache_ttl = 300 if follow_type == 'ignore' else 30
 
     return await db.query_all(sql, account_id=account_id,
                               limit=page_size, offset=page*page_size,
-                              cache_key=cache_key, cache_ttl=30)
+                              cache_key=cache_key, cache_ttl=cache_ttl)
 
 async def get_following(db, account: str, start: str, follow_type: str, limit: int):
     """Get a list of accounts followed by a given account."""
@@ -178,10 +183,11 @@ async def get_following(db, account: str, start: str, follow_type: str, limit: i
         str(limit)
     ]
     cache_key = '_'.join(cache_key_parts)
+    cache_ttl = 300 if follow_type == 'ignore' else 30
 
     return await db.query_all(sql, account_id=account_id, start_id=start_id,
                               limit=limit,
-                              cache_key=cache_key, cache_ttl=30)
+                              cache_key=cache_key, cache_ttl=cache_ttl)
 
 
 async def get_following_by_page(db, account: str, page: int, page_size: int, follow_type: str):
@@ -219,10 +225,11 @@ async def get_following_by_page(db, account: str, page: int, page_size: int, fol
         str(page_size)
     ]
     cache_key = '_'.join(cache_key_parts)
+    cache_ttl = 300 if follow_type == 'ignore' else 30
 
     return await db.query_all(sql, account_id=account_id,
                               limit=page_size, offset=page*page_size,
-                              cache_key=cache_key, cache_ttl=30)
+                              cache_key=cache_key, cache_ttl=cache_ttl)
 
 
 async def get_follow_counts(db, account: str):


### PR DESCRIPTION
## Summary

Short-term mitigation for the three slow-query classes that caused the 2026-07-12 beta-hivemind outage (ELB MaxResponseTime 30s, jussi 502s, ~2h duration). Targets the 21.9s / 12.9s / 12.7s queries identified in the RDS slow log. No architecture changes — maximally reuses existing patterns (the `@cacher` decorator, `pids_by_blog` caching, the `CONCURRENTLY` migration style from #367/#371).

Investigation report: `agent-share/notes/hivemind/2026-07-12-beta-hivemind-slow-query-investigation.md`

## Changes

### 1. Follow queries — hardcode state + cache (`5f566a6`)
`get_followers`, `get_followers_by_page`, `get_following_by_page` were uncached (only `get_following` had a 30s cache). The parameterized `state IN :state` tuple binding also prevented the planner from matching the v23 partial index `idx_follows_follower_state_created_desc` (`WHERE state IN (1,3)`), forcing a fallback to the full-ASC `ix5a` with a cross-value sort — **the 21.9s query**.

- Hardcode `state IN (1,3)` / `state IN (2,3)` literals so the planner can use the partial index
- Add 30s cache to the three uncached functions (aligns with `get_following`)
- Complete the INNER JOIN migration for `get_following_by_page` (missed in `3274329` and `67c6d5e` where its three siblings were converted)

### 2. Tag filtering — cache (`eed7f5e`)
`pids_by_category` (bridge_api) and `pids_by_query` (condenser_api) ran uncached. Hot tags match tens of thousands of `post_id`s via `IN (subquery)` — **the 12.9s query**. Apply the same `query_col` + `cache_key` pattern already used by `pids_by_blog` in the same file, with a 60s TTL.

### 3. Symmetric follows index + drop duplicates (`d35e4a4`, v28→v29)
`get_followers` (`WHERE following = :id ORDER BY created_at DESC`) had **no `following`-led partial index** — the only one (`idx_follows_follower_state_created_desc`) is `follower`-led and serves `get_following`. Hardcoding `state` (change #1) is not enough without a symmetric index; this is the real fix for the 21.9s query.

- Add `idx_follows_following_state_created_desc` `(following, state, created_at DESC, follower) WHERE state IN (1,3)`
- Drop `hive_follows_5a`/`5b`: legacy v9 duplicates of `ix5a`/`ix5b` (identical columns), pure write-amplification; never managed by `_disableable_indexes`
- Bumps `DB_VERSION` 28→29

### 4. Reduce `fetch_ranks` frequency (`56a60e7`)
`Accounts.fetch_ranks` runs `SELECT id FROM hive_accounts ORDER BY vote_weight DESC` (full-table sort of million-scale rows, ~12s) hourly on the indexer's sync connection — **the 12.7s query**. Separate from the API pool but competes for RDS IOPS (which hit the 3000 cap during the outage). Reduced to every 6h; rank is an approximate notification-bucket score, a 6h stale window is acceptable.

## Verification
- [x] All 5 files byte-compile (`py_compile`)
- [x] Diff reviewed line-by-line; clean (no formatting noise)
- [x] Static checks: `state=` bindings removed from all 4 follow funcs; cache_key+cache_ttl on all target functions; DB_VERSION=29; migration block complete
- [ ] **`make test-all` not run** — local env has no PostgreSQL and the `aiopg` git-tarball dependency times out to install. Test suite requires a live DB; deferred to CI.

## Out of scope (mid/long-term, per investigation report)
- Redis sorted-set caching for follow graph / tags
- Read replica for API queries; raise RDS IOPS
- Table partitioning

## Deployment notes
- The v28→v29 migration runs on `hive sync` startup via `CREATE INDEX CONCURRENTLY` (no table lock), but consumes IOPS while building on the large `hive_follows` table — **recommend deploying during a low-traffic window**. Migration logs: `[HIVE] Creating idx_follows_following_state_created_desc index...`
- Caching requires `REDIS_URL` to be configured (the `@cacher` decorator skips cache when `redis_cache is None`)