### PR TITLE
perf: fix N+1 queries in load_posts_keyed, add DB pool timeout

### DIFF
--- a/hive/server/bridge_api/objects.py
+++ b/hive/server/bridge_api/objects.py
@@ -85,29 +85,49 @@ async def load_posts_keyed(db, ids, truncate_body=0):
                 ctx[cid] = []
             ctx[cid].append(author['id'])
 
-    # TODO: optimize
-    titles = {}
-    roles = {}
-    for cid, account_ids in ctx.items():
-        sql = "SELECT title FROM hive_communities WHERE id = :id"
-        titles[cid] = await db.query_one(sql, id=cid)
-        sql = """SELECT account_id, role_id, title
-                   FROM hive_roles
-                  WHERE community_id = :cid
-                    AND account_id IN :ids"""
-        roles[cid] = {}
-        ret = await db.query_all(sql, cid=cid, ids=tuple(account_ids))
-        for row in ret:
-            name = author_ids[row['account_id']]
-            roles[cid][name] = (row['role_id'], row['title'])
+    # Batch load community titles and roles in 2 queries instead of one
+    # pair of queries per community, which could tie up many DB connections
+    # under burst traffic across threads spanning many communities.
+    # Pre-initialize maps for every referenced community so lookups below
+    # never raise KeyError when a community_id points at a row that no longer
+    # exists in hive_communities (e.g. after a fork rollback deletes it) --
+    # such rows simply fall back to the post category / default guest role,
+    # matching the pre-batch behavior.
+    titles = {cid: None for cid in ctx}
+    roles = {cid: {} for cid in ctx}
+    if ctx:
+        all_cids = tuple(ctx.keys())
+
+        # 1 query for all community titles
+        sql = "SELECT id, title FROM hive_communities WHERE id IN :cids"
+        for r in await db.query_all(sql, cids=all_cids):
+            titles[r['id']] = r['title']
+
+        # Collect unique account_ids across all communities
+        all_aids = set()
+        for aids in ctx.values():
+            all_aids.update(aids)
+
+        if all_aids:
+            # 1 query for all roles across all communities
+            sql = """SELECT community_id, account_id, role_id, title
+                       FROM hive_roles
+                      WHERE community_id IN :cids
+                        AND account_id IN :aids"""
+            ret = await db.query_all(sql, cids=all_cids, aids=tuple(all_aids))
+            for row in ret:
+                cid = row['community_id']
+                name = author_ids.get(row['account_id'])
+                if name and cid in roles:
+                    roles[cid][name] = (row['role_id'], row['title'])
 
     for pid, post in posts_by_id.items():
         author = post['author']
         cid = post_cids[pid]
         if cid:
             post['community'] = post['category'] # TODO: True?
-            post['community_title'] = titles[cid] or post['category']
-            role = roles[cid][author] if author in roles[cid] else (0, '')
+            post['community_title'] = titles.get(cid) or post['category']
+            role = roles[cid][author] if cid in roles and author in roles[cid] else (0, '')
             post['author_role'] = ROLES[role[0]]
             post['author_title'] = role[1]
         else:

--- a/hive/server/bridge_api/thread.py
+++ b/hive/server/bridge_api/thread.py
@@ -71,7 +71,7 @@ async def _child_ids(db, parent_ids):
         GROUP BY p.parent_id
     """
     rows = await db.query_all(sql, ids=tuple(parent_ids),
-        cache_key="_child_ids_" + "_".join(map(str, parent_ids)), cache_ttl=30)
+        cache_key="_child_ids_" + "_".join(map(str, parent_ids)), cache_ttl=120)
     return [[row['parent_id'], row['child_ids']] for row in rows]
 
 async def _load_discussion(db, root_id):

--- a/hive/server/db.py
+++ b/hive/server/db.py
@@ -99,6 +99,7 @@ class Db:
                                       host=conf.host,
                                       port=conf.port,
                                       maxsize=pool_size,
+                                      timeout=10,
                                       **conf.query)
         if redis_url is not None:
             self.redis_cache = Cache.from_url(redis_url)


### PR DESCRIPTION
## Summary

Three targeted performance fixes to address recurring hivemind outage (every 1-2 days, EB health goes Yellow with ~46% 4xx).

### Root cause
`get_discussion` pipeline exhausts the 25-connection aiopg pool under burst traffic, starving health checks → ELB marks instance unhealthy → EB replaces it.

### Changes

1. **Eliminate N+1 community queries** (`objects.py:load_posts_keyed`)
   - Merged per-community title + role queries into 2 batch queries
   - Reduces DB round-trips from 2N to 2 (N = number of communities in thread)
   - A thread spanning 30 communities previously issued 60 extra queries

2. **Add connection pool acquisition timeout** (`db.py`)
   - `aiopg.sa.create_engine(timeout=10)`
   - If all connections are busy, fail fast in 10s instead of blocking indefinitely
   - Normal queries complete in <1s; 10s is a safe upper bound
   - Prevents connection starvation cascading into health check failure

3. **Increase `_child_ids` cache TTL** (`thread.py`)
   - 30s → 120s
   - Reduces repeated BFS lookups on deep comment trees
   - Most comment trees are static after initial load

### Verification
- `make fmt` ✓
- `python3 -m py_compile` ✓ (all 3 files)
- Logic reviewed against production Scalyr logs showing `get_discussion` as 50% of failure traffic