### PR TITLE
perf: remove statement_timeout, keep health_db isolation + pool timeout

### DIFF
--- a/hive/server/db.py
+++ b/hive/server/db.py
@@ -16,14 +16,6 @@ log = logging.getLogger(__name__)
 
 CACHE_NAMESPACE = "hivemind"
 
-# Per-query execution timeout (milliseconds). PostgreSQL cancels any statement
-# running longer than this, immediately releasing the connection back to the
-# pool. This is the safety net that prevents a single pathological query (e.g.
-# 160s get_discussion lookups) from exhausting the aiopg pool. The pool's
-# acquire `timeout` only bounds how long we wait for a free connection, NOT
-# query execution time. See connection-pool-exhaustion incident.
-STATEMENT_TIMEOUT_MS = 30000  # 30 seconds
-
 # Sentinel value to represent 'record not found' in cache.
 # Using a string marker that can be easily serialized/deserialized.
 # This allows us to distinguish between:
@@ -105,21 +97,6 @@ class Db:
     async def init(self, url, redis_url, pool_size=20):
         """Initialize the aiopg.sa engine."""
         conf = make_url(url)
-        # statement_timeout (ms) cancels runaway queries server-side so a single
-        # slow query cannot hold a pool connection indefinitely. See note on
-        # STATEMENT_TIMEOUT_MS above. Passed via the standard libpq `options`
-        # string (every psycopg2/libpq version accepts this); the newer
-        # `server_settings` dict is rejected as an invalid DSN option by the
-        # older psycopg2 shipped in the runtime image. Merge into conf.query
-        # (rather than a separate kwarg) so a DATABASE_URL that already carries
-        # an `options=...` query param does not cause a duplicate-keyword error;
-        # any pre-existing options string is preserved and appended to.
-        query = dict(conf.query)
-        timeout_opt = '-c statement_timeout=%d' % STATEMENT_TIMEOUT_MS
-        if 'options' in query and query['options']:
-            query['options'] = query['options'] + ' ' + timeout_opt
-        else:
-            query['options'] = timeout_opt
         self.db = await create_engine(user=conf.username,
                                       database=conf.database,
                                       password=conf.password,
@@ -127,7 +104,7 @@ class Db:
                                       port=conf.port,
                                       maxsize=pool_size,
                                       timeout=10,
-                                      **query)
+                                      **conf.query)
         # Lightweight isolated engine (1 connection) for health checks. A short
         # acquire timeout keeps health checks responsive instead of blocking.
         self.health_db = await create_engine(user=conf.username,
@@ -137,7 +114,7 @@ class Db:
                                              port=conf.port,
                                              maxsize=1,
                                              timeout=2,
-                                             **query)
+                                             **conf.query)
         if redis_url is not None:
             self.redis_cache = Cache.from_url(redis_url)
             self.redis_cache.serializer = SafeUniversalSerializer()


### PR DESCRIPTION
## Summary

Reverts the `statement_timeout=30s` change from PR #375 while keeping all four safe changes.

## Background

PR #375 introduced `statement_timeout=30000` (via libpq `options` string) to cap runaway queries server-side. In production (2026-08-01) this caused a **query amplification loop**:

```
PG cancels query at 30s → releases connection
  → hivemind async handler NOT cancelled → grabs new connection
    → new query also times out → repeat
      → RDS flooded with retried queries → I/O saturates
        → simple queries (200ms normal) take 341s+
          → hivemind memory piles to 99% (8GB c5.xlarge)
```

Root cause: `statement_timeout` kills the PG query but does NOT cancel the Python async coroutine (aiopg has no mechanism for this). The freed connection is immediately reused for a retried query, creating more concurrent load than before.

## Changes

**Removed:**
- `STATEMENT_TIMEOUT_MS = 30000` constant
- `options` string construction in `init()` (`-c statement_timeout=30000`)
- `query` dict merge logic (back to `**conf.query` directly)

**Kept (from PR #375):**
- ✅ `health_db`: isolated `maxsize=1` engine for `/health` and `/head_age`
- ✅ `MAX_DEPTH=50` / `MAX_THREAD_POSTS=500`: bounds `_load_discussion` recursion
- ✅ hide_id lookups cached (300s TTL): reduces per-request DB connections
- ✅ Pool acquire `timeout=10` (from PR #374)

## Why Now

Inbound load is now controlled at the openresty layer ([steemit/openresty#18](https://github.com/steemit/openresty/pull/18)): `get_state` dual-track rate limiting (internal aggregate 30r/s + external per-IP 10r/s). This reduces hivemind inbound traffic at the source rather than killing queries server-side, avoiding the async-handler-not-cancelled trap entirely.

After openresty rate limiting deployment, hivemind slow queries dropped from 10k+/5min to 0-71/5min, and the system is healthy. The remaining safe changes (health_db isolation, recursion caps, cache) further harden hivemind without the statement_timeout risk.

## Verification

- `db.py` syntax verified (ast.parse)
- No `statement_timeout` / `STATEMENT_TIMEOUT` / `timeout_opt` references remain
- `health_db` and `conf.query` usage intact
- Unit tests from PR #375 (`tests/bridge_thread/`) unchanged — they test the thread recursion caps, not statement_timeout