### PR TITLE
fix(models): resolve Payment model/DDL type mismatch + add 0002 migration

### DIFF
--- a/internal/db/migrations/0002_payments_extras.down.sql
+++ b/internal/db/migrations/0002_payments_extras.down.sql
@@ -1,0 +1,6 @@
+-- =====================================================================
+-- 0002 down: remove the Go-indexer-only extras from hive_payments.
+-- =====================================================================
+
+ALTER TABLE hive_payments DROP COLUMN IF EXISTS created_at;
+ALTER TABLE hive_payments DROP COLUMN IF EXISTS memo;

--- a/internal/db/migrations/0002_payments_extras.up.sql
+++ b/internal/db/migrations/0002_payments_extras.up.sql
@@ -1,0 +1,14 @@
+-- =====================================================================
+-- 0002: Add memo and created_at to hive_payments.
+--
+-- The legacy Python hive_payments schema (schema.py) does not define these
+-- columns, but the Go payment_indexer writes them (memo is parsed from the
+-- transfer op; created_at is the block date). Rather than discard data the
+-- indexer already produces, add them as nullable/loosely-typed extras so the
+-- Go model, indexer, and DB schema stay consistent.
+--
+-- These are intentionally additive and do not touch any legacy column.
+-- =====================================================================
+
+ALTER TABLE hive_payments ADD COLUMN IF NOT EXISTS memo VARCHAR(1024);
+ALTER TABLE hive_payments ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT '1970-01-01 00:00:00';

--- a/internal/indexer/payment_indexer.go
+++ b/internal/indexer/payment_indexer.go
@@ -59,12 +59,12 @@ func (pay *PaymentIndexer) ProcessTransfer(ctx context.Context, tx *gorm.DB, op 
 		if len(parts) == 2 {
 			author := parts[0]
 			permlink := parts[1]
-			
+
 			postRepo := db.NewPostRepository(pay.repo)
 			post, err := postRepo.GetByAuthorPermlink(ctx, author, permlink)
 			if err == nil && post != nil {
 				postID = post.ID
-				
+
 				// Update post promoted amount
 				post.Promoted += amount
 				if err := tx.WithContext(ctx).Save(post).Error; err != nil {
@@ -74,17 +74,30 @@ func (pay *PaymentIndexer) ProcessTransfer(ctx context.Context, tx *gorm.DB, op 
 		}
 	}
 
+	// Resolve account names to IDs (hive_payments.from_account/to_account are
+	// INTEGER FKs to hive_accounts.id). 'null' and the sender must already be
+	// registered (block_processor registers accounts observed in the block).
+	accountRepo := db.NewAccountRepository(pay.repo)
+	fromAccount, err := accountRepo.GetByName(ctx, from)
+	if err != nil || fromAccount == nil {
+		return fmt.Errorf("payment sender not registered: %s", from)
+	}
+	toAccount, err := accountRepo.GetByName(ctx, to)
+	if err != nil || toAccount == nil {
+		return fmt.Errorf("payment recipient not registered: %s", to)
+	}
+
 	// Record payment
 	payment := &models.Payment{
-		BlockNum: blockNum,
-		TXIndex:  0, // TODO: Get actual transaction index
-		From:     from,
-		To:       to,
-		Amount:   amount,
-		Token:    token,
-		Memo:     memo,
-		PostID:   postID,
-		CreatedAt: blockDate,
+		BlockNum:      blockNum,
+		TXIndex:       0, // TODO: Get actual transaction index
+		PostID:        postID,
+		FromAccountID: fromAccount.ID,
+		ToAccountID:   toAccount.ID,
+		Amount:        amount,
+		Token:         token,
+		Memo:          memo,
+		CreatedAt:     blockDate,
 	}
 
 	if err := tx.WithContext(ctx).Create(payment).Error; err != nil {
@@ -106,12 +119,11 @@ func parseAmount(amountStr string) (float64, error) {
 	if len(parts) == 0 {
 		return 0, fmt.Errorf("invalid amount format")
 	}
-	
+
 	amount, err := strconv.ParseFloat(parts[0], 64)
 	if err != nil {
 		return 0, err
 	}
-	
+
 	return amount, nil
 }
-

--- a/internal/models/payment.go
+++ b/internal/models/payment.go
@@ -4,22 +4,33 @@ import (
 	"time"
 )
 
-// Payment represents a payment operation
+// Payment represents a payment operation.
+//
+// Mirrors legacy schema.py hive_payments: from_account/to_account are INTEGER
+// foreign keys referencing hive_accounts.id (not account-name strings). The
+// Go indexer resolves account names to IDs before writing.
+//
+// NOTE: the legacy Python schema does NOT define `memo` or `created_at`
+// columns. They are retained here because the existing payment_indexer writes
+// them; migration 0002 adds them to the DB so model/indexer/schema stay
+// consistent.
 type Payment struct {
-	ID        int64     `gorm:"primaryKey;autoIncrement;column:id"`
-	BlockNum  int64     `gorm:"not null;column:block_num"`
-	TXIndex   int16     `gorm:"type:smallint;not null;column:tx_idx"`
-	From      string    `gorm:"type:varchar(16);not null;column:from_account"`
-	To        string    `gorm:"type:varchar(16);not null;column:to_account"`
-	Amount    float64   `gorm:"type:decimal(10,3);not null;column:amount"`
-	Token     string    `gorm:"type:varchar(5);not null;column:token"`
+	ID            int64   `gorm:"primaryKey;autoIncrement;column:id"`
+	BlockNum      int64   `gorm:"not null;column:block_num"`
+	TXIndex       int16   `gorm:"type:smallint;not null;column:tx_idx"`
+	PostID        int64   `gorm:"not null;column:post_id"`
+	FromAccountID int64   `gorm:"not null;column:from_account"`
+	ToAccountID   int64   `gorm:"not null;column:to_account"`
+	Amount        float64 `gorm:"type:decimal(10,3);not null;column:amount"`
+	Token         string  `gorm:"type:varchar(5);not null;column:token"`
+
+	// Extra columns written by the Go indexer; added by migration 0002.
 	Memo      string    `gorm:"type:varchar(1024);column:memo"`
-	PostID    int64     `gorm:"column:post_id"`
 	CreatedAt time.Time `gorm:"not null;column:created_at"`
 
 	// Relationships
-	FromAccount *Account `gorm:"foreignKey:From;references:Name"`
-	ToAccount   *Account `gorm:"foreignKey:To;references:Name"`
+	FromAccount *Account `gorm:"foreignKey:FromAccountID;references:ID"`
+	ToAccount   *Account `gorm:"foreignKey:ToAccountID;references:ID"`
 	Post        *Post    `gorm:"foreignKey:PostID;references:ID"`
 }
 
@@ -27,4 +38,3 @@ type Payment struct {
 func (Payment) TableName() string {
 	return "hive_payments"
 }
-


### PR DESCRIPTION
## Problem

PR #377 (`feat(db): migration framework`) was merged with a known intermediate state on `next`:
1. **Payment model `From/To` is `string`**, but the baseline DDL (`0001`) declares `from_account`/`to_account` as `INTEGER` FKs → indexer writing account-name strings to INTEGER columns fails.
2. **Migration `0002` (memo/created_at) was missing** → the Payment model and `payment_indexer` reference columns that don't exist in the DB after a fresh migration.

This PR resolves both so `next` returns to a consistent, runnable state.

## Changes
- **Migration `0002_payments_extras`**: adds `memo VARCHAR(1024)` and `created_at TIMESTAMP` to `hive_payments` (Go indexer extras not in legacy schema.py).
- **`internal/models/payment.go`**: `From`/`To` `string` → `FromAccountID`/`ToAccountID` `int64` (FK → `hive_accounts.id`); `PostID` `not null`.
- **`internal/indexer/payment_indexer.go`**: resolves account names to IDs via `AccountRepository.GetByName` before writing.

## Validation (Postgres 15)
- `0001` + `0002` migrate cleanly on fresh DB (version=2).
- `hive_payments`: `from_account`/`to_account` are `integer` FKs; `memo` + `created_at` columns present.
- End-to-end: register accounts → create post → insert payment with integer FKs + memo → succeeds.

```
 from_account | to_account | amount | token |    memo     |     created_at
--------------+------------+--------+-------+-------------+---------------------
            8 |          2 | 10.000 | SBD   | @alice/test | 2026-01-01 00:00:00
```

- `go build` / `go vet` / `go test ./...` all green.

## Test plan
- [ ] CI green
- [ ] Fresh DB: `0001` + `0002` apply, payment insert with integer FK works
- [ ] Existing legacy DB: `HIVE_DB_MIGRATE_FORCE=1` stamps baseline, then `0002` applies `ADD COLUMN IF NOT EXISTS` (idempotent)

Addresses audit findings #1 and #2 from [`pr-377-audit.md`](https://github.com/steemit/hivemind/blob/next/).