### PR TITLE
fix(models): align remaining GORM models with legacy Python schema (KR1)

### DIFF
--- a/internal/api/objects/post.go
+++ b/internal/api/objects/post.go
@@ -110,32 +110,32 @@ func (l *PostLoader) buildPostObject(ctx context.Context, post *models.Post, cac
 		body = body[:truncateBody]
 	}
 
-	jsonMetadata := cache.JSONMeta
+	jsonMetadata := cache.JSON
 	if jsonMetadata == "" {
 		jsonMetadata = "{}"
 	}
 
 	postObj := map[string]interface{}{
-		"id":                post.ID,
-		"author":            account.Name,
-		"permlink":          post.Permlink,
-		"category":          post.Category,
-		"title":             cache.Title,
-		"body":              body,
-		"json_metadata":     jsonMetadata,
-		"created":           post.CreatedAt.Format(time.RFC3339),
-		"last_update":       cache.UpdatedAt.Format(time.RFC3339),
-		"depth":             post.Depth,
-		"children":          cache.Children,
-		"net_rshares":       cache.RShares,
-		"url":               fmt.Sprintf("/%s/@%s/%s", post.Category, account.Name, post.Permlink),
-		"active_votes":      []interface{}{}, // TODO: Load active votes from cache.Votes (format needs to be parsed)
-		"replies":           []interface{}{},  // TODO: Load replies (requires querying child posts)
-		"reblogged_by":      l.getRebloggedBy(ctx, post.ID), // Load reblogs
-		"body_length":       len(cache.Body),
-		"author_reputation": account.Reputation,
-		"promoted":          post.Promoted,
-		"payout":            cache.Payout,
+		"id":                   post.ID,
+		"author":               account.Name,
+		"permlink":             post.Permlink,
+		"category":             post.Category,
+		"title":                cache.Title,
+		"body":                 body,
+		"json_metadata":        jsonMetadata,
+		"created":              post.CreatedAt.Format(time.RFC3339),
+		"last_update":          cache.UpdatedAt.Format(time.RFC3339),
+		"depth":                post.Depth,
+		"children":             cache.Children,
+		"net_rshares":          cache.RShares,
+		"url":                  fmt.Sprintf("/%s/@%s/%s", post.Category, account.Name, post.Permlink),
+		"active_votes":         []interface{}{},                // TODO: Load active votes from cache.Votes (format needs to be parsed)
+		"replies":              []interface{}{},                // TODO: Load replies (requires querying child posts)
+		"reblogged_by":         l.getRebloggedBy(ctx, post.ID), // Load reblogs
+		"body_length":          len(cache.Body),
+		"author_reputation":    account.Reputation,
+		"promoted":             post.Promoted,
+		"payout":               cache.Payout,
 		"pending_payout_value": cache.Payout, // TODO: Check if paid out
 	}
 
@@ -203,4 +203,3 @@ func (l *PostLoader) getRebloggedBy(ctx context.Context, postID int64) []interfa
 
 	return result
 }
-

--- a/internal/db/model_schema_align_test.go
+++ b/internal/db/model_schema_align_test.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steemit/hivemind/internal/models"
+)
+
+// TestModelColumnsExistInSchema verifies that every column referenced by a
+// GORM model tag actually exists in the migrated database schema. This catches
+// drift between the Go model definitions and the baseline migration — the
+// core acceptance criterion of KR1 ("Go models 100% compatible with Python
+// schema").
+//
+// Run with:
+//
+//	HIVE_TEST_DATABASE_URL=postgresql://test:test@localhost:5433/hive go test -run TestModelColumnsExistInSchema ./internal/db/...
+func TestModelColumnsExistInSchema(t *testing.T) {
+	dbURL := os.Getenv("HIVE_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("HIVE_TEST_DATABASE_URL not set; skipping model/schema alignment test")
+	}
+	resetSchema(t, dbURL)
+	if err := RunMigrations(dbURL, 0); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	raw, err := openRawForTest(dbURL)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer raw.Close()
+
+	expected := map[string][]string{
+		"hive_state":            columnNames(models.State{}),
+		"hive_blocks":           columnNames(models.Block{}),
+		"hive_accounts":         columnNames(models.Account{}),
+		"hive_posts":            columnNames(models.Post{}),
+		"hive_post_tags":        columnNames(models.PostTag{}),
+		"hive_follows":          columnNames(models.Follow{}),
+		"hive_reblogs":          columnNames(models.Reblog{}),
+		"hive_payments":         columnNames(models.Payment{}),
+		"hive_feed_cache":       columnNames(models.FeedCache{}),
+		"hive_posts_cache":      columnNames(models.PostCache{}),
+		"hive_posts_cache_temp": columnNames(models.PostCacheTemp{}),
+		"hive_communities":      columnNames(models.Community{}),
+		"hive_roles":            columnNames(models.Role{}),
+		"hive_subscriptions":    columnNames(models.Subscription{}),
+		"hive_notifs":           columnNames(models.Notification{}),
+		"hive_posts_status":     columnNames(models.PostStatus{}),
+		"hive_trxid_block_num":  columnNames(models.TransactionBlock{}),
+	}
+
+	for table, wantCols := range expected {
+		rows, err := raw.Query(`SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1`, table)
+		if err != nil {
+			t.Fatalf("query columns for %s: %v", table, err)
+		}
+		gotSet := map[string]bool{}
+		for rows.Next() {
+			var c string
+			rows.Scan(&c)
+			gotSet[c] = true
+		}
+		rows.Close()
+
+		for _, col := range wantCols {
+			if !gotSet[col] {
+				t.Errorf("table %s: model references column %q but it is missing from the DB schema", table, col)
+			}
+		}
+	}
+}
+
+// TestSchemaColumnsCoveredByModels is the reverse check: every column in the
+// DB schema should be represented in a model (catches missing model fields).
+func TestSchemaColumnsCoveredByModels(t *testing.T) {
+	dbURL := os.Getenv("HIVE_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("HIVE_TEST_DATABASE_URL not set")
+	}
+	resetSchema(t, dbURL)
+	if err := RunMigrations(dbURL, 0); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	raw, err := openRawForTest(dbURL)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer raw.Close()
+
+	modelCols := map[string]map[string]bool{
+		"hive_state":            toSet(columnNames(models.State{})),
+		"hive_blocks":           toSet(columnNames(models.Block{})),
+		"hive_accounts":         toSet(columnNames(models.Account{})),
+		"hive_posts":            toSet(columnNames(models.Post{})),
+		"hive_post_tags":        toSet(columnNames(models.PostTag{})),
+		"hive_follows":          toSet(columnNames(models.Follow{})),
+		"hive_reblogs":          toSet(columnNames(models.Reblog{})),
+		"hive_payments":         toSet(columnNames(models.Payment{})),
+		"hive_feed_cache":       toSet(columnNames(models.FeedCache{})),
+		"hive_posts_cache":      toSet(columnNames(models.PostCache{})),
+		"hive_posts_cache_temp": toSet(columnNames(models.PostCacheTemp{})),
+		"hive_communities":      toSet(columnNames(models.Community{})),
+		"hive_roles":            toSet(columnNames(models.Role{})),
+		"hive_subscriptions":    toSet(columnNames(models.Subscription{})),
+		"hive_notifs":           toSet(columnNames(models.Notification{})),
+		"hive_posts_status":     toSet(columnNames(models.PostStatus{})),
+		"hive_trxid_block_num":  toSet(columnNames(models.TransactionBlock{})),
+	}
+
+	for table, cols := range modelCols {
+		rows, err := raw.Query(`SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1`, table)
+		if err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		for rows.Next() {
+			var c string
+			rows.Scan(&c)
+			if !cols[c] {
+				t.Errorf("table %s: DB column %q has no corresponding model field", table, c)
+			}
+		}
+		rows.Close()
+	}
+}
+
+func toSet(s []string) map[string]bool {
+	m := make(map[string]bool, len(s))
+	for _, v := range s {
+		m[v] = true
+	}
+	return m
+}

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"time"
 
-	"gorm.io/gorm"
 	"github.com/steemit/hivemind/internal/models"
+	"gorm.io/gorm"
 )
 
 // Repository provides database access methods
@@ -206,11 +206,11 @@ func (r *NotificationRepository) GetByDstID(ctx context.Context, dstID int64, mi
 		Where("dst_id = ? AND score >= ?", dstID, minScore).
 		Order("id DESC").
 		Limit(limit)
-	
+
 	if lastID > 0 {
 		query = query.Where("id < ?", lastID)
 	}
-	
+
 	if err := query.Find(&notifications).Error; err != nil {
 		return nil, err
 	}
@@ -224,11 +224,11 @@ func (r *NotificationRepository) GetByCommunityID(ctx context.Context, community
 		Where("community_id = ? AND score >= ?", communityID, minScore).
 		Order("id DESC").
 		Limit(limit)
-	
+
 	if lastID > 0 {
 		query = query.Where("id < ?", lastID)
 	}
-	
+
 	if err := query.Find(&notifications).Error; err != nil {
 		return nil, err
 	}
@@ -242,11 +242,11 @@ func (r *NotificationRepository) GetByPostID(ctx context.Context, postID int64, 
 		Where("post_id = ? AND score >= ?", postID, minScore).
 		Order("id DESC").
 		Limit(limit)
-	
+
 	if lastID > 0 {
 		query = query.Where("id < ?", lastID)
 	}
-	
+
 	if err := query.Find(&notifications).Error; err != nil {
 		return nil, err
 	}
@@ -508,7 +508,7 @@ func (r *FollowRepository) GetByFollowerFollowing(ctx context.Context, followerI
 // CreateOrUpdate creates or updates a follow relationship
 func (r *FollowRepository) CreateOrUpdate(ctx context.Context, follow *models.Follow) error {
 	return r.db.WithContext(ctx).
-		Where("follower = ? AND following = ?", follow.Follower, follow.Following).
+		Where("follower = ? AND following = ?", follow.FollowerID, follow.FollowingID).
 		Assign(*follow).
 		FirstOrCreate(follow).Error
 }
@@ -560,4 +560,3 @@ func (r *FollowRepository) GetFollowingPaginated(ctx context.Context, followerID
 
 	return follows, nil
 }
-

--- a/internal/db/test_helpers_test.go
+++ b/internal/db/test_helpers_test.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"database/sql"
+	"reflect"
+	"strings"
+	"sync"
+
+	"gorm.io/gorm/schema"
+)
+
+// openRawForTest opens a *sql.DB against dbURL using the pgx driver, for
+// ad-hoc information_schema queries in tests.
+func openRawForTest(dbURL string) (*sql.DB, error) {
+	return sql.Open("pgx", dbURL)
+}
+
+// extractColumnNames reads the `gorm` struct tags of a model and returns the
+// declared DB column names in field order. Uses GORM's schema.Parse so the
+// parsing matches exactly how GORM itself interprets the tags.
+func extractColumnNames(model interface{}) []string {
+	cache := &sync.Map{}
+	s, err := schema.Parse(model, cache, schema.NamingStrategy{})
+	if err != nil {
+		return manualColumnNames(model)
+	}
+	cols := make([]string, 0, len(s.Fields))
+	for _, f := range s.Fields {
+		if f.DBName != "" {
+			cols = append(cols, f.DBName)
+		}
+	}
+	return cols
+}
+
+// columnNames is the public-facing alias used by alignment tests.
+func columnNames(model interface{}) []string {
+	return extractColumnNames(model)
+}
+
+// manualColumnNames is a fallback tag parser used only if schema.Parse fails.
+func manualColumnNames(model interface{}) []string {
+	t := reflect.TypeOf(model)
+	var cols []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("gorm")
+		col := ""
+		for _, part := range strings.Split(tag, ";") {
+			part = strings.TrimSpace(part)
+			if strings.HasPrefix(part, "column:") {
+				col = strings.TrimPrefix(part, "column:")
+				break
+			}
+		}
+		if col != "" {
+			cols = append(cols, col)
+		}
+	}
+	return cols
+}

--- a/internal/indexer/block_processor.go
+++ b/internal/indexer/block_processor.go
@@ -2,7 +2,9 @@ package indexer
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -15,31 +17,31 @@ import (
 
 // BlockProcessor processes blockchain blocks
 type BlockProcessor struct {
-	db              *db.DB
-	repo            *db.Repository
-	accounts        *AccountIndexer
-	posts           *PostIndexer
-	follows         *FollowIndexer
-	payments        *PaymentIndexer
-	customOps       *CustomOpProcessor
+	db               *db.DB
+	repo             *db.Repository
+	accounts         *AccountIndexer
+	posts            *PostIndexer
+	follows          *FollowIndexer
+	payments         *PaymentIndexer
+	customOps        *CustomOpProcessor
 	communityIndexer *CommunityIndexer
-	logger          *zap.Logger
+	logger           *zap.Logger
 }
 
 // NewBlockProcessor creates a new block processor
 func NewBlockProcessor(database *db.DB, repo *db.Repository) *BlockProcessor {
 	logger := logging.GetLogger().With(zap.String("component", "block-processor"))
-	
+
 	return &BlockProcessor{
-		db:              database,
-		repo:            repo,
-		accounts:        NewAccountIndexer(repo, logger),
-		posts:           NewPostIndexer(repo, logger),
-		follows:         NewFollowIndexer(repo, logger),
-		payments:        NewPaymentIndexer(repo, logger),
-		customOps:       NewCustomOpProcessor(repo, logger),
+		db:               database,
+		repo:             repo,
+		accounts:         NewAccountIndexer(repo, logger),
+		posts:            NewPostIndexer(repo, logger),
+		follows:          NewFollowIndexer(repo, logger),
+		payments:         NewPaymentIndexer(repo, logger),
+		customOps:        NewCustomOpProcessor(repo, logger),
 		communityIndexer: NewCommunityIndexer(repo, logger),
-		logger:          logger,
+		logger:           logger,
 	}
 }
 
@@ -78,7 +80,7 @@ func (bp *BlockProcessor) processBlockInTx(ctx context.Context, tx *gorm.DB, blo
 	blockHash := block["block_id"].(string)
 	prevHash := block["previous"].(string)
 	timestamp := block["timestamp"].(string)
-	
+
 	blockDate, err := time.Parse("2006-01-02T15:04:05", timestamp)
 	if err != nil {
 		return fmt.Errorf("failed to parse block timestamp: %w", err)
@@ -175,7 +177,7 @@ func (bp *BlockProcessor) processBlockInTx(ctx context.Context, tx *gorm.DB, blo
 		if err := bp.accounts.Register(ctx, tx, accountNamesList, blockDate); err != nil {
 			return fmt.Errorf("failed to register accounts: %w", err)
 		}
-		
+
 		// Check if any new accounts are communities and register them
 		if err := bp.communityIndexer.Register(ctx, tx, accountNamesList, blockDate); err != nil {
 			bp.logger.Warn("Failed to register communities", zap.Error(err))
@@ -207,7 +209,7 @@ func (bp *BlockProcessor) saveTransactionIDs(ctx context.Context, tx *gorm.DB, t
 			continue
 		}
 		records = append(records, models.TransactionBlock{
-			TrxID:    trxID,
+			TrxID:    sql.NullString{String: trxID, Valid: true},
 			BlockNum: blockNum,
 		})
 	}
@@ -216,18 +218,26 @@ func (bp *BlockProcessor) saveTransactionIDs(ctx context.Context, tx *gorm.DB, t
 		return nil
 	}
 
-	// Use ON CONFLICT DO NOTHING to handle duplicates
+	// Batch insert with ON CONFLICT DO NOTHING. The legacy v19 schema uses a
+	// PARTIAL unique index (hive_trxid_ix1 ON (trx_id) WHERE trx_id IS NOT
+	// NULL), so the conflict target is that index name.
+	values := make([]string, 0, len(records))
+	args := make([]interface{}, 0, len(records)*2)
+	for _, r := range records {
+		values = append(values, "(?, ?)")
+		args = append(args, r.TrxID.String, r.BlockNum)
+	}
 	if err := tx.WithContext(ctx).
 		Exec("INSERT INTO hive_trxid_block_num (trx_id, block_num) VALUES "+
-			"(?, ?) ON CONFLICT (trx_id) DO NOTHING",
-			records[0].TrxID, records[0].BlockNum).Error; err != nil {
+			strings.Join(values, ", ")+" ON CONFLICT (trx_id) DO NOTHING",
+			args...).Error; err != nil {
 		// Fallback to individual inserts if batch fails
 		for _, record := range records {
 			if err := tx.WithContext(ctx).
 				Where("trx_id = ?", record.TrxID).
 				FirstOrCreate(&record).Error; err != nil {
 				bp.logger.Warn("Failed to save transaction ID",
-					zap.String("trx_id", record.TrxID),
+					zap.String("trx_id", record.TrxID.String),
 					zap.Int64("block", blockNum),
 					zap.Error(err))
 			}
@@ -302,14 +312,14 @@ func (bp *BlockProcessor) processOperation(
 			author, _ := opValue["author"].(string)
 			voter, _ := opValue["voter"].(string)
 			permlink, _ := opValue["permlink"].(string)
-			
+
 			if author != "" {
 				bp.accounts.MarkDirty(author)
 			}
 			if voter != "" {
 				bp.accounts.MarkDirty(voter)
 			}
-			
+
 			// Mark post for cache update
 			if author != "" && permlink != "" {
 				if err := bp.posts.MarkPostDirty(ctx, tx, author, permlink); err != nil {
@@ -332,4 +342,3 @@ func (bp *BlockProcessor) processOperation(
 
 	return nil
 }
-

--- a/internal/indexer/community_indexer.go
+++ b/internal/indexer/community_indexer.go
@@ -82,7 +82,7 @@ func (ci *CommunityIndexer) Register(ctx context.Context, tx *gorm.DB, accountNa
 		role := &models.Role{
 			CommunityID: account.ID,
 			AccountID:   account.ID,
-			Role:        models.RoleOwner,
+			RoleID:      models.RoleOwner,
 			CreatedAt:   blockDate,
 		}
 
@@ -247,13 +247,13 @@ func (ci *CommunityIndexer) processSetRole(ctx context.Context, tx *gorm.DB, op 
 	role := &models.Role{
 		CommunityID: communityID,
 		AccountID:   account.ID,
-		Role:        roleID,
+		RoleID:      roleID,
 		CreatedAt:   blockDate,
 	}
 
 	if err := tx.WithContext(ctx).
 		Where("community_id = ? AND account_id = ?", communityID, account.ID).
-		Assign(models.Role{Role: roleID, CreatedAt: blockDate}).
+		Assign(models.Role{RoleID: roleID, CreatedAt: blockDate}).
 		FirstOrCreate(role).Error; err != nil {
 		return fmt.Errorf("failed to set role: %w", err)
 	}
@@ -416,4 +416,3 @@ func (ci *CommunityIndexer) roleNameToID(roleName string) int16 {
 		return models.RoleGuest
 	}
 }
-

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -7,41 +7,41 @@ import (
 
 // Account represents a Steem account
 type Account struct {
-	ID          int64          `gorm:"primaryKey;autoIncrement;column:id"`
-	Name        string         `gorm:"type:varchar(16);not null;uniqueIndex:hive_accounts_ux1;column:name"`
-	CreatedAt   time.Time      `gorm:"not null;column:created_at"`
-	Reputation  float64        `gorm:"type:float(6);not null;default:25;column:reputation"`
-	
+	ID         int64     `gorm:"primaryKey;autoIncrement;column:id"`
+	Name       string    `gorm:"type:varchar(16);not null;uniqueIndex:hive_accounts_ux1;column:name"`
+	CreatedAt  time.Time `gorm:"not null;column:created_at"`
+	Reputation float64   `gorm:"type:float(6);not null;default:25;column:reputation"`
+
 	// Profile fields
-	DisplayName sql.NullString `gorm:"type:varchar(20);column:display_name"`
-	About       sql.NullString `gorm:"type:varchar(160);column:about"`
-	Location    sql.NullString `gorm:"type:varchar(30);column:location"`
-	Website     sql.NullString `gorm:"type:varchar(100);column:website"`
-	ProfileImage string        `gorm:"type:varchar(1024);not null;default:'';column:profile_image"`
-	CoverImage   string        `gorm:"type:varchar(1024);not null;default:'';column:cover_image"`
-	
+	DisplayName  sql.NullString `gorm:"type:varchar(20);column:display_name"`
+	About        sql.NullString `gorm:"type:varchar(160);column:about"`
+	Location     sql.NullString `gorm:"type:varchar(30);column:location"`
+	Website      sql.NullString `gorm:"type:varchar(100);column:website"`
+	ProfileImage string         `gorm:"type:varchar(1024);not null;default:'';column:profile_image"`
+	CoverImage   string         `gorm:"type:varchar(1024);not null;default:'';column:cover_image"`
+
 	// Social stats
-	Followers   int64         `gorm:"not null;default:0;column:followers"`
-	Following   int64         `gorm:"not null;default:0;column:following"`
-	
+	Followers int64 `gorm:"not null;default:0;column:followers"`
+	Following int64 `gorm:"not null;default:0;column:following"`
+
 	// Voting
-	Proxy       string        `gorm:"type:varchar(16);not null;default:'';column:proxy"`
-	PostCount   int64         `gorm:"not null;default:0;column:post_count"`
-	ProxyWeight float64       `gorm:"type:float(6);not null;default:0;column:proxy_weight"`
-	VoteWeight  float64       `gorm:"type:float(6);not null;default:0;column:vote_weight"`
-	Rank        int64         `gorm:"not null;default:0;column:rank"`
-	
+	Proxy       string  `gorm:"type:varchar(16);not null;default:'';column:proxy"`
+	PostCount   int64   `gorm:"not null;default:0;column:post_count"`
+	ProxyWeight float64 `gorm:"type:float(6);not null;default:0;column:proxy_weight"`
+	VoteWeight  float64 `gorm:"type:float(6);not null;default:0;column:vote_weight"`
+	KBUsed      int64   `gorm:"not null;default:0;column:kb_used"` // deprecated in legacy but still in schema
+	Rank        int64   `gorm:"not null;default:0;column:rank"`
+
 	// Activity tracking
-	LastreadAt time.Time     `gorm:"not null;default:'1970-01-01 00:00:00';column:lastread_at"`
-	ActiveAt   time.Time     `gorm:"not null;default:'1970-01-01 00:00:00';column:active_at"`
-	CachedAt   time.Time     `gorm:"not null;default:'1970-01-01 00:00:00';column:cached_at"`
-	
+	LastreadAt time.Time `gorm:"not null;default:'1970-01-01 00:00:00';column:lastread_at"`
+	ActiveAt   time.Time `gorm:"not null;default:'1970-01-01 00:00:00';column:active_at"`
+	CachedAt   time.Time `gorm:"not null;default:'1970-01-01 00:00:00';column:cached_at"`
+
 	// Raw data
-	RawJSON    sql.NullString `gorm:"type:text;column:raw_json"`
+	RawJSON sql.NullString `gorm:"type:text;column:raw_json"`
 }
 
 // TableName specifies the table name for Account
 func (Account) TableName() string {
 	return "hive_accounts"
 }
-

--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -21,4 +21,3 @@ type Block struct {
 func (Block) TableName() string {
 	return "hive_blocks"
 }
-

--- a/internal/models/cache.go
+++ b/internal/models/cache.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql"
 	"time"
 )
 
@@ -20,28 +21,50 @@ func (FeedCache) TableName() string {
 	return "hive_feed_cache"
 }
 
-// PostCache represents cached post data with computed fields
+// PostCache represents cached post data with computed fields (hive_posts_cache).
+//
+// Mirrors legacy schema.py hive_posts_cache (32 columns, DB_VERSION 29).
+// NOTE: the bulk JSON column is named `json` (NOT `json_metadata`) in the
+// legacy schema. The API layer exposes it under the condenser-compatible
+// `json_metadata` key — that mapping lives in the API handlers, not here.
 type PostCache struct {
-	PostID    int64     `gorm:"primaryKey;column:post_id"`
-	Author    string    `gorm:"type:varchar(16);not null;column:author"`
-	Permlink  string    `gorm:"type:varchar(255);not null;column:permlink"`
-	Category  string    `gorm:"type:varchar(255);column:category"`
-	Title     string    `gorm:"type:varchar(255);column:title"`
-	Body      string    `gorm:"type:text;column:body"`
-	JSONMeta  string    `gorm:"type:text;column:json_metadata"`
-	CreatedAt time.Time `gorm:"not null;column:created_at"`
-	UpdatedAt time.Time `gorm:"not null;column:updated_at"`
-	
-	// Computed fields
-	SCTrend   float64   `gorm:"type:float;column:sc_trend"`
-	SCHot     float64   `gorm:"type:float;column:sc_hot"`
-	Payout    float64   `gorm:"type:decimal(10,3);column:payout"`
-	RShares   int64     `gorm:"column:rshares"`
-	Votes     string    `gorm:"type:text;column:votes"`
-	Children  int64     `gorm:"column:children"`
-	Preview   string    `gorm:"type:varchar(1024);column:preview"`
-	ImgURL    string    `gorm:"type:varchar(1024);column:img_url"`
-	
+	PostID      int64         `gorm:"primaryKey;column:post_id"`
+	Author      string        `gorm:"type:varchar(16);not null;column:author"`
+	Permlink    string        `gorm:"type:varchar(255);not null;column:permlink"`
+	Category    string        `gorm:"type:varchar(255);not null;default:'';column:category"`
+	CommunityID sql.NullInt64 `gorm:"column:community_id"`
+	Depth       int16         `gorm:"type:smallint;not null;default:0;column:depth"`
+	Children    int16         `gorm:"type:smallint;not null;default:0;column:children"`
+	AuthorRep   float64       `gorm:"type:float(6);not null;default:0;column:author_rep"`
+	FlagWeight  float64       `gorm:"type:float(6);not null;default:0;column:flag_weight"`
+	TotalVotes  int64         `gorm:"not null;default:0;column:total_votes"`
+	UpVotes     int64         `gorm:"not null;default:0;column:up_votes"`
+	Title       string        `gorm:"type:varchar(255);not null;default:'';column:title"`
+	Preview     string        `gorm:"type:varchar(1024);not null;default:'';column:preview"`
+	ImgURL      string        `gorm:"type:varchar(1024);not null;default:'';column:img_url"`
+	Payout      float64       `gorm:"type:decimal(10,3);not null;default:0;column:payout"`
+	Promoted    float64       `gorm:"type:decimal(10,3);not null;default:0;column:promoted"`
+	CreatedAt   time.Time     `gorm:"not null;default:'1990-01-01';column:created_at"`
+	PayoutAt    time.Time     `gorm:"not null;default:'1990-01-01';column:payout_at"`
+	UpdatedAt   time.Time     `gorm:"not null;default:'1990-01-01';column:updated_at"`
+	IsPaidout   bool          `gorm:"not null;default:false;column:is_paidout"`
+	IsNSFW      bool          `gorm:"not null;default:false;column:is_nsfw"`
+	IsDeclined  bool          `gorm:"not null;default:false;column:is_declined"`
+	IsFullPower bool          `gorm:"not null;default:false;column:is_full_power"`
+	IsHidden    bool          `gorm:"not null;default:false;column:is_hidden"`
+	IsGrayed    bool          `gorm:"not null;default:false;column:is_grayed"`
+
+	// Computed / frequently-changing fields
+	RShares int64   `gorm:"not null;default:0;column:rshares"`
+	SCTrend float64 `gorm:"type:float(6);not null;default:0;column:sc_trend"`
+	SCHot   float64 `gorm:"type:float(6);not null;default:0;column:sc_hot"`
+
+	// Large/variable fields
+	Body    string `gorm:"type:text;column:body"`
+	Votes   string `gorm:"type:text;column:votes"`
+	JSON    string `gorm:"type:text;column:json"`
+	RawJSON string `gorm:"type:text;column:raw_json"`
+
 	// Relationships
 	Post *Post `gorm:"foreignKey:PostID;references:ID"`
 }
@@ -51,3 +74,49 @@ func (PostCache) TableName() string {
 	return "hive_posts_cache"
 }
 
+// PostCacheTemp mirrors PostCache in the hive_posts_cache_temp table, which
+// holds a rolling 90-day hot-data window pruned by the CacheSync background
+// job. It is identical to PostCache plus a _synced_at column tracking the
+// last dual-write.
+type PostCacheTemp struct {
+	PostID      int64         `gorm:"primaryKey;column:post_id"`
+	Author      string        `gorm:"type:varchar(16);not null;column:author"`
+	Permlink    string        `gorm:"type:varchar(255);not null;column:permlink"`
+	Category    string        `gorm:"type:varchar(255);not null;default:'';column:category"`
+	CommunityID sql.NullInt64 `gorm:"column:community_id"`
+	Depth       int16         `gorm:"type:smallint;not null;default:0;column:depth"`
+	Children    int16         `gorm:"type:smallint;not null;default:0;column:children"`
+	AuthorRep   float64       `gorm:"type:float(6);not null;default:0;column:author_rep"`
+	FlagWeight  float64       `gorm:"type:float(6);not null;default:0;column:flag_weight"`
+	TotalVotes  int64         `gorm:"not null;default:0;column:total_votes"`
+	UpVotes     int64         `gorm:"not null;default:0;column:up_votes"`
+	Title       string        `gorm:"type:varchar(255);not null;default:'';column:title"`
+	Preview     string        `gorm:"type:varchar(1024);not null;default:'';column:preview"`
+	ImgURL      string        `gorm:"type:varchar(1024);not null;default:'';column:img_url"`
+	Payout      float64       `gorm:"type:decimal(10,3);not null;default:0;column:payout"`
+	Promoted    float64       `gorm:"type:decimal(10,3);not null;default:0;column:promoted"`
+	CreatedAt   time.Time     `gorm:"not null;default:'1990-01-01';column:created_at"`
+	PayoutAt    time.Time     `gorm:"not null;default:'1990-01-01';column:payout_at"`
+	UpdatedAt   time.Time     `gorm:"not null;default:'1990-01-01';column:updated_at"`
+	IsPaidout   bool          `gorm:"not null;default:false;column:is_paidout"`
+	IsNSFW      bool          `gorm:"not null;default:false;column:is_nsfw"`
+	IsDeclined  bool          `gorm:"not null;default:false;column:is_declined"`
+	IsFullPower bool          `gorm:"not null;default:false;column:is_full_power"`
+	IsHidden    bool          `gorm:"not null;default:false;column:is_hidden"`
+	IsGrayed    bool          `gorm:"not null;default:false;column:is_grayed"`
+
+	RShares int64   `gorm:"not null;default:0;column:rshares"`
+	SCTrend float64 `gorm:"type:float(6);not null;default:0;column:sc_trend"`
+	SCHot   float64 `gorm:"type:float(6);not null;default:0;column:sc_hot"`
+
+	Body     string       `gorm:"type:text;column:body"`
+	Votes    string       `gorm:"type:text;column:votes"`
+	JSON     string       `gorm:"type:text;column:json"`
+	RawJSON  string       `gorm:"type:text;column:raw_json"`
+	SyncedAt sql.NullTime `gorm:"column:_synced_at"`
+}
+
+// TableName specifies the table name for PostCacheTemp
+func (PostCacheTemp) TableName() string {
+	return "hive_posts_cache_temp"
+}

--- a/internal/models/community.go
+++ b/internal/models/community.go
@@ -42,11 +42,11 @@ const (
 
 // Role represents a community role
 type Role struct {
-	CommunityID int64          `gorm:"primaryKey;column:community_id"`
-	AccountID   int64          `gorm:"primaryKey;column:account_id"`
-	Role        int16          `gorm:"type:smallint;not null;default:0;column:role"`
-	Title       sql.NullString `gorm:"type:varchar(140);column:title"`
-	CreatedAt   time.Time      `gorm:"not null;column:created_at"`
+	CommunityID int64     `gorm:"primaryKey;column:community_id"`
+	AccountID   int64     `gorm:"primaryKey;column:account_id"`
+	RoleID      int16     `gorm:"type:smallint;not null;default:0;column:role_id"`
+	Title       string    `gorm:"type:varchar(140);not null;default:'';column:title"`
+	CreatedAt   time.Time `gorm:"not null;column:created_at"`
 
 	// Relationships
 	Community *Community `gorm:"foreignKey:CommunityID;references:ID"`
@@ -83,4 +83,3 @@ type Subscription struct {
 func (Subscription) TableName() string {
 	return "hive_subscriptions"
 }
-

--- a/internal/models/follow.go
+++ b/internal/models/follow.go
@@ -4,11 +4,15 @@ import (
 	"time"
 )
 
-// Follow represents a follow relationship
+// Follow represents a follow relationship.
+//
+// Mirrors legacy schema.py hive_follows: the `state` column defaults to 1
+// (blog follow), not 0. The state is a bitfield: bit 0 = blog follow,
+// bit 1 = ignore.
 type Follow struct {
 	FollowerID  int64     `gorm:"primaryKey;column:follower"`
 	FollowingID int64     `gorm:"primaryKey;column:following"`
-	State       int16     `gorm:"type:smallint;not null;default:0;column:state"`
+	State       int16     `gorm:"type:smallint;not null;default:1;column:state"`
 	CreatedAt   time.Time `gorm:"not null;column:created_at"`
 
 	// Relationships
@@ -21,11 +25,11 @@ func (Follow) TableName() string {
 	return "hive_follows"
 }
 
-// Follow state constants
+// Follow state bitfield constants. The schema default is FollowStateBlog (1),
+// so a freshly inserted row with no explicit state represents a blog follow.
 const (
-	FollowStateNone   int16 = 0 // No relationship
-	FollowStateBlog   int16 = 1 // Blog follow
+	FollowStateNone   int16 = 0 // No relationship (explicitly cleared)
+	FollowStateBlog   int16 = 1 // Blog follow (schema default)
 	FollowStateIgnore int16 = 2 // Ignore
 	FollowStateBoth   int16 = 3 // Blog follow + ignore
 )
-

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -5,16 +5,21 @@ import (
 	"time"
 )
 
-// Notification represents a notification
+// Notification represents a notification.
+//
+// Mirrors legacy schema.py hive_notifs: type_id is NOT NULL with no default,
+// score is NOT NULL (legacy has no server_default, so no default here either),
+// and block_num is a nullable tracking column (added by migration).
 type Notification struct {
 	ID          int64          `gorm:"primaryKey;autoIncrement;column:id"`
 	Type        int16          `gorm:"type:smallint;not null;column:type_id"`
-	Score       int16          `gorm:"type:smallint;not null;default:0;column:score"`
+	Score       int16          `gorm:"type:smallint;not null;column:score"`
 	CreatedAt   time.Time      `gorm:"not null;column:created_at"`
 	SrcID       sql.NullInt64  `gorm:"column:src_id"`
 	DstID       sql.NullInt64  `gorm:"column:dst_id"`
 	CommunityID sql.NullInt64  `gorm:"column:community_id"`
 	PostID      sql.NullInt64  `gorm:"column:post_id"`
+	BlockNum    sql.NullInt64  `gorm:"column:block_num"`
 	Payload     sql.NullString `gorm:"type:text;column:payload"`
 
 	// Relationships
@@ -31,22 +36,21 @@ func (Notification) TableName() string {
 
 // Notification type constants
 const (
-	NotifyTypeNewCommunity  int16 = 1
-	NotifyTypeSetRole       int16 = 2
-	NotifyTypeSetProps      int16 = 3
-	NotifyTypeSetLabel      int16 = 4
-	NotifyTypeMutePost      int16 = 5
-	NotifyTypeUnmutePost    int16 = 6
-	NotifyTypePinPost       int16 = 7
-	NotifyTypeUnpinPost     int16 = 8
-	NotifyTypeFlagPost      int16 = 9
-	NotifyTypeError          int16 = 10
-	NotifyTypeSubscribe     int16 = 11
-	NotifyTypeReply          int16 = 12
-	NotifyTypeReplyComment   int16 = 13
-	NotifyTypeReblog         int16 = 14
-	NotifyTypeFollow         int16 = 15
-	NotifyTypeMention        int16 = 16
-	NotifyTypeVote           int16 = 17
+	NotifyTypeNewCommunity int16 = 1
+	NotifyTypeSetRole      int16 = 2
+	NotifyTypeSetProps     int16 = 3
+	NotifyTypeSetLabel     int16 = 4
+	NotifyTypeMutePost     int16 = 5
+	NotifyTypeUnmutePost   int16 = 6
+	NotifyTypePinPost      int16 = 7
+	NotifyTypeUnpinPost    int16 = 8
+	NotifyTypeFlagPost     int16 = 9
+	NotifyTypeError        int16 = 10
+	NotifyTypeSubscribe    int16 = 11
+	NotifyTypeReply        int16 = 12
+	NotifyTypeReplyComment int16 = 13
+	NotifyTypeReblog       int16 = 14
+	NotifyTypeFollow       int16 = 15
+	NotifyTypeMention      int16 = 16
+	NotifyTypeVote         int16 = 17
 )
-

--- a/internal/models/post.go
+++ b/internal/models/post.go
@@ -7,23 +7,23 @@ import (
 
 // Post represents a post or comment
 type Post struct {
-	ID          int64          `gorm:"primaryKey;autoIncrement;column:id"`
-	ParentID    sql.NullInt64  `gorm:"column:parent_id"`
-	Author      string         `gorm:"type:varchar(16);not null;column:author"`
-	Permlink    string         `gorm:"type:varchar(255);not null;column:permlink"`
-	Category    string         `gorm:"type:varchar(255);column:category"`
-	CommunityID sql.NullInt64  `gorm:"column:community_id"`
-	CreatedAt   time.Time      `gorm:"not null;column:created_at"`
-	Depth       int16          `gorm:"type:smallint;column:depth"`
-	IsDeleted   bool           `gorm:"not null;default:false;column:is_deleted"`
-	IsPinned    bool           `gorm:"not null;default:false;column:is_pinned"`
-	IsMuted     bool           `gorm:"not null;default:false;column:is_muted"`
-	IsValid     bool           `gorm:"not null;default:true;column:is_valid"`
-	Promoted    float64        `gorm:"type:decimal(10,3);default:0;column:promoted"`
+	ID          int64         `gorm:"primaryKey;autoIncrement;column:id"`
+	ParentID    sql.NullInt64 `gorm:"column:parent_id"`
+	Author      string        `gorm:"type:varchar(16);not null;column:author"`
+	Permlink    string        `gorm:"type:varchar(255);not null;column:permlink"`
+	Category    string        `gorm:"type:varchar(255);not null;default:'';column:category"`
+	CommunityID sql.NullInt64 `gorm:"column:community_id"`
+	CreatedAt   time.Time     `gorm:"not null;column:created_at"`
+	Depth       int16         `gorm:"type:smallint;not null;column:depth"`
+	IsDeleted   bool          `gorm:"not null;default:false;column:is_deleted"`
+	IsPinned    bool          `gorm:"not null;default:false;column:is_pinned"`
+	IsMuted     bool          `gorm:"not null;default:false;column:is_muted"`
+	IsValid     bool          `gorm:"not null;default:true;column:is_valid"`
+	Promoted    float64       `gorm:"type:decimal(10,3);not null;default:0;column:promoted"`
 
 	// Relationships
-	Parent   *Post   `gorm:"foreignKey:ParentID;references:ID"`
-	Children []Post  `gorm:"foreignKey:ParentID;references:ID"`
+	Parent        *Post    `gorm:"foreignKey:ParentID;references:ID"`
+	Children      []Post   `gorm:"foreignKey:ParentID;references:ID"`
 	AuthorAccount *Account `gorm:"foreignKey:Author;references:Name"`
 }
 
@@ -42,4 +42,3 @@ type PostTag struct {
 func (PostTag) TableName() string {
 	return "hive_post_tags"
 }
-

--- a/internal/models/reblog.go
+++ b/internal/models/reblog.go
@@ -19,4 +19,3 @@ type Reblog struct {
 func (Reblog) TableName() string {
 	return "hive_reblogs"
 }
-

--- a/internal/models/schema_align_test.go
+++ b/internal/models/schema_align_test.go
@@ -1,0 +1,64 @@
+package models
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestTableNameUniqueness ensures no two models accidentally share a table
+// name (a common copy-paste bug when adding models).
+func TestTableNameUniqueness(t *testing.T) {
+	tables := []string{
+		(State{}).TableName(),
+		(Block{}).TableName(),
+		(Account{}).TableName(),
+		(Post{}).TableName(),
+		(PostTag{}).TableName(),
+		(Follow{}).TableName(),
+		(Reblog{}).TableName(),
+		(Payment{}).TableName(),
+		(FeedCache{}).TableName(),
+		(PostCache{}).TableName(),
+		(PostCacheTemp{}).TableName(),
+		(Community{}).TableName(),
+		(Role{}).TableName(),
+		(Subscription{}).TableName(),
+		(Notification{}).TableName(),
+		(PostStatus{}).TableName(),
+		(TransactionBlock{}).TableName(),
+	}
+	sort.Strings(tables)
+	for i := 1; i < len(tables); i++ {
+		if tables[i] == tables[i-1] {
+			t.Errorf("duplicate table name: %q", tables[i])
+		}
+	}
+}
+
+// TestPostStatusListTypeConstants pins the list_type values to the legacy
+// semantics so future refactors cannot silently shift them.
+func TestPostStatusListTypeConstants(t *testing.T) {
+	if PostStatusArticleBlock != 1 {
+		t.Errorf("PostStatusArticleBlock = %d, want 1", PostStatusArticleBlock)
+	}
+	if PostStatusArticlePin != 2 {
+		t.Errorf("PostStatusArticlePin = %d, want 2", PostStatusArticlePin)
+	}
+	if PostStatusUserBlock != 3 {
+		t.Errorf("PostStatusUserBlock = %d, want 3", PostStatusUserBlock)
+	}
+}
+
+// TestFollowStateConstants pins the state bitfield values and documents that
+// the schema default is blog follow (1).
+func TestFollowStateConstants(t *testing.T) {
+	if FollowStateBlog != 1 {
+		t.Errorf("FollowStateBlog = %d, want 1 (schema default)", FollowStateBlog)
+	}
+	if FollowStateIgnore != 2 {
+		t.Errorf("FollowStateIgnore = %d, want 2", FollowStateIgnore)
+	}
+	if FollowStateBoth != 3 {
+		t.Errorf("FollowStateBoth = %d, want 3", FollowStateBoth)
+	}
+}

--- a/internal/models/state.go
+++ b/internal/models/state.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"time"
 )
 
 // State represents the database state
@@ -19,12 +20,19 @@ func (State) TableName() string {
 	return "hive_state"
 }
 
-// PostStatus represents post status flags
+// PostStatus represents an entry in the hive_posts_status table, which tracks
+// blacklist/pin/block lists. This is NOT the per-post is_pinned/is_muted/is_valid
+// flags (those live on hive_posts); it is a separate append-only status table
+// keyed by an auto-increment id with a list_type discriminator.
+//
+// Mirrors legacy schema.py hive_posts_status (DB_VERSION 29, v20 production
+// shape: no UNIQUE constraint, three separate indexes).
 type PostStatus struct {
-	PostID    int64 `gorm:"primaryKey;column:post_id"`
-	IsPinned  bool  `gorm:"not null;default:false;column:is_pinned"`
-	IsMuted   bool  `gorm:"not null;default:false;column:is_muted"`
-	IsValid   bool  `gorm:"not null;default:true;column:is_valid"`
+	ID        int64     `gorm:"primaryKey;autoIncrement;column:id"`
+	PostID    int64     `gorm:"not null;default:0;column:post_id"`
+	Author    string    `gorm:"type:varchar(16);not null;default:'';column:author"`
+	ListType  int16     `gorm:"type:smallint;not null;default:0;column:list_type"`
+	CreatedAt time.Time `gorm:"not null;default:'1990-01-01';column:created_at"`
 }
 
 // TableName specifies the table name for PostStatus
@@ -32,14 +40,23 @@ func (PostStatus) TableName() string {
 	return "hive_posts_status"
 }
 
-// TransactionBlock represents transaction ID to block number mapping
+// PostStatus list_type values (legacy hive/server/common/helpers.py).
+const (
+	PostStatusArticleBlock int16 = 1 // Block a specific post
+	PostStatusArticlePin   int16 = 2 // Pin a specific post
+	PostStatusUserBlock    int16 = 3 // Block all posts by an author
+)
+
+// TransactionBlock represents transaction ID to block number mapping.
+//
+// Mirrors the legacy v19 production shape: trx_id is NULLABLE (a partial unique
+// index hive_trxid_ix1 covers non-null values), and there is no primary key.
 type TransactionBlock struct {
-	TrxID    string `gorm:"primaryKey;type:varchar(40);column:trx_id"`
-	BlockNum int64  `gorm:"not null;column:block_num"`
+	TrxID    sql.NullString `gorm:"type:varchar(40);column:trx_id"`
+	BlockNum int64          `gorm:"not null;column:block_num"`
 }
 
 // TableName specifies the table name for TransactionBlock
 func (TransactionBlock) TableName() string {
 	return "hive_trxid_block_num"
 }
-


### PR DESCRIPTION
## Summary

Completes the KR1 model alignment started in #378 (Payment). Rewrites the remaining models so every GORM struct tag matches the production `DB_VERSION=29` shape.

## Model changes
- **PostStatus**: complete rewrite (`id/post_id/author/list_type/created_at`). Old `is_pinned/is_muted/is_valid` belonged to `hive_posts`, not this blacklist/pin/block-list table.
- **PostCache**: add 15 missing columns (`community_id`, `depth`, `author_rep`, `flag_weight`, `total_votes`/, `promoted`, `payout_at`, `is_paidout`/////, `raw_json`), fix JSON column name (`json_metadata` → `json`).
- **PostCacheTemp**: new model mirroring PostCache + `_synced_at` for the 90-day hot-data table (KR4 CacheSync).
- **Role**: column `role` → `role_id`; `Title` nullable → not-null string.
- **Notification**: add `block_num`; drop `score` default.
- **Follow**: `state` default `0` → `1` (schema default is blog follow).
- **Account**: add deprecated `kb_used`; **Post**: `category`// not null.
- **TransactionBlock**: `trx_id` nullable (v19 partial unique index shape).

## Consumer updates
- `community_indexer.go`: `Role` → `RoleID` (3 sites).
- `block_processor.go`: adapts to nullable `TrxID` (`sql.NullString`) and **fixes a batch-insert bug** (only the first trx-id record was being persisted).
- `repository.go`: `CreateOrUpdate` uses `FollowerID`/`FollowingID` (was referencing relationship pointers).
- `objects/post.go`: reads renamed `cache.JSON` (API output key `json_metadata` unchanged).

## Validation
- `go build` / `go vet` / `go test ./...` all green.
- **Bidirectional model↔schema alignment test** (Postgres 15): 17 tables, every GORM tag column verified present in DB and vice-versa.
- `TestModelColumnsExistInSchema` + `TestSchemaColumnsCoveredByModels` both pass.

## Test plan
- [ ] CI green
- [ ] Alignment test passes in CI (if PG available)

Part of Q3 O4 / KR1. Depends on #378 (Payment fix, already merged).