### PR TITLE
refactor(steem): introduce Provider interface for dependency injection (KR5a)

### DIFF
--- a/internal/indexer/account_indexer.go
+++ b/internal/indexer/account_indexer.go
@@ -10,21 +10,26 @@ import (
 
 	"github.com/steemit/hivemind/internal/db"
 	"github.com/steemit/hivemind/internal/models"
+	"github.com/steemit/hivemind/internal/steem"
 )
 
 // AccountIndexer handles account indexing
 type AccountIndexer struct {
 	repo   *db.Repository
+	steem  steem.Provider
 	logger *zap.Logger
 	dirty  map[string]bool // Dirty queue for accounts that need updates
 }
 
-// NewAccountIndexer creates a new account indexer
-func NewAccountIndexer(repo *db.Repository, logger *zap.Logger) *AccountIndexer {
+// NewAccountIndexer creates a new account indexer. The steem provider is used
+// by Flush (KR3) to pull fresh account data from steemd; it may be nil in tests
+// that only exercise Register/MarkDirty.
+func NewAccountIndexer(repo *db.Repository, logger *zap.Logger, steemProvider steem.Provider) *AccountIndexer {
 	return &AccountIndexer{
 		repo:   repo,
+		steem:  steemProvider,
 		logger: logger,
-		dirty:   make(map[string]bool),
+		dirty:  make(map[string]bool),
 	}
 }
 
@@ -35,7 +40,7 @@ func (ai *AccountIndexer) Register(ctx context.Context, tx *gorm.DB, names []str
 	}
 
 	accountRepo := db.NewAccountRepository(ai.repo)
-	
+
 	// Filter out accounts that already exist
 	newNames := make([]string, 0)
 	for _, name := range names {
@@ -55,15 +60,15 @@ func (ai *AccountIndexer) Register(ctx context.Context, tx *gorm.DB, names []str
 	// Create new accounts
 	for _, name := range newNames {
 		account := &models.Account{
-			Name:      name,
-			CreatedAt: blockDate,
+			Name:       name,
+			CreatedAt:  blockDate,
 			Reputation: 25.0, // Default reputation
 		}
-		
+
 		if err := tx.WithContext(ctx).Create(account).Error; err != nil {
 			return fmt.Errorf("failed to create account %s: %w", name, err)
 		}
-		
+
 		ai.logger.Debug("Registered new account", zap.String("name", name))
 	}
 
@@ -84,7 +89,7 @@ func (ai *AccountIndexer) Flush(ctx context.Context) error {
 	// TODO: Fetch accounts from steemd and update cache
 	// For now, just clear the dirty queue
 	ai.dirty = make(map[string]bool)
-	
+
 	return nil
 }
 
@@ -100,4 +105,3 @@ func (ai *AccountIndexer) GetID(ctx context.Context, name string) (int64, error)
 	}
 	return account.ID, nil
 }
-

--- a/internal/indexer/block_processor.go
+++ b/internal/indexer/block_processor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steemit/hivemind/internal/db"
 	"github.com/steemit/hivemind/internal/models"
+	"github.com/steemit/hivemind/internal/steem"
 	"github.com/steemit/hivemind/pkg/logging"
 )
 
@@ -19,6 +20,7 @@ import (
 type BlockProcessor struct {
 	db               *db.DB
 	repo             *db.Repository
+	steem            steem.Provider
 	accounts         *AccountIndexer
 	posts            *PostIndexer
 	follows          *FollowIndexer
@@ -28,14 +30,18 @@ type BlockProcessor struct {
 	logger           *zap.Logger
 }
 
-// NewBlockProcessor creates a new block processor
-func NewBlockProcessor(database *db.DB, repo *db.Repository) *BlockProcessor {
+// NewBlockProcessor creates a new block processor. The steemProvider is passed
+// down to indexers that need to hit steemd (currently AccountIndexer.Flush;
+// CachedPost in KR2 will use it for get_content_batch). Pass nil only in tests
+// that exercise pure-DB code paths.
+func NewBlockProcessor(database *db.DB, repo *db.Repository, steemProvider steem.Provider) *BlockProcessor {
 	logger := logging.GetLogger().With(zap.String("component", "block-processor"))
 
 	return &BlockProcessor{
 		db:               database,
 		repo:             repo,
-		accounts:         NewAccountIndexer(repo, logger),
+		steem:            steemProvider,
+		accounts:         NewAccountIndexer(repo, logger, steemProvider),
 		posts:            NewPostIndexer(repo, logger),
 		follows:          NewFollowIndexer(repo, logger),
 		payments:         NewPaymentIndexer(repo, logger),

--- a/internal/indexer/sync.go
+++ b/internal/indexer/sync.go
@@ -18,15 +18,17 @@ import (
 type Sync struct {
 	config         *config.Config
 	db             *db.DB
-	steem          *steem.Client
+	steem          steem.Provider
 	blockProcessor *BlockProcessor
 	logger         *zap.Logger
 }
 
-// NewSync creates a new sync manager
-func NewSync(cfg *config.Config, database *db.DB, steemClient *steem.Client) (*Sync, error) {
+// NewSync creates a new sync manager. The steemClient is accepted as the
+// Provider interface so tests can inject a mock; the concrete *steem.Client
+// satisfies it (see internal/steem/provider.go).
+func NewSync(cfg *config.Config, database *db.DB, steemClient steem.Provider) (*Sync, error) {
 	repo := db.NewRepository(database.DB)
-	blockProcessor := NewBlockProcessor(database, repo)
+	blockProcessor := NewBlockProcessor(database, repo, steemClient)
 
 	return &Sync{
 		config:         cfg,
@@ -102,7 +104,7 @@ func (s *Sync) initialSync(ctx context.Context, feedCacheRepo *db.FeedCacheRepos
 		s.logger.Info("Syncing blocks for initial sync",
 			zap.Int64("from", currentHead+1),
 			zap.Int64("to", irreversible))
-		
+
 		if err := s.syncBlocks(ctx, currentHead+1, irreversible); err != nil {
 			return fmt.Errorf("failed to sync blocks: %w", err)
 		}

--- a/internal/steem/provider.go
+++ b/internal/steem/provider.go
@@ -1,0 +1,44 @@
+package steem
+
+import "context"
+
+// Provider is the abstraction over the Steem RPC surface that the indexer and
+// API layers depend on. The concrete *Client implements it; tests inject a
+// mock to avoid hitting a live steemd node.
+//
+// Defining this interface (rather than depending on the concrete *Client) is
+// the KR5 prerequisite: it lets CachedPost (KR2), AccountIndexer.Flush (KR3),
+// and the condenser get_transaction handler (KR6) be unit-tested, and keeps
+// the dependency direction one-way (indexer/api -> interface <- steem impl).
+//
+// Only the methods actually consumed by callers are listed. Add methods here
+// when a new consumer needs them, so the interface stays intentionally small.
+type Provider interface {
+	// GetBlock fetches a single block by number.
+	GetBlock(ctx context.Context, num int64) (map[string]interface{}, error)
+
+	// GetBlocksRange fetches blocks [from, to] inclusive.
+	GetBlocksRange(ctx context.Context, from, to int64) ([]map[string]interface{}, error)
+
+	// GetAccounts fetches up to 1000 accounts by name (steemd get_accounts).
+	GetAccounts(ctx context.Context, names []string) ([]map[string]interface{}, error)
+
+	// GetContent fetches a single post by author/permlink (steemd get_content).
+	GetContent(ctx context.Context, author, permlink string) (map[string]interface{}, error)
+
+	// GetContentBatch fetches multiple posts (steemd get_content per item).
+	GetContentBatch(ctx context.Context, posts [][]string) ([]map[string]interface{}, error)
+
+	// GetDynamicGlobalProperties returns the chain's dynamic global properties.
+	GetDynamicGlobalProperties(ctx context.Context) (map[string]interface{}, error)
+
+	// HeadBlock returns the current head block number.
+	HeadBlock(ctx context.Context) (int64, error)
+
+	// LastIrreversible returns the last irreversible block number.
+	LastIrreversible(ctx context.Context) (int64, error)
+}
+
+// Compile-time assertion that *Client satisfies Provider. If a method is added
+// to the interface without a matching implementation, this fails the build.
+var _ Provider = (*Client)(nil)

--- a/internal/steem/provider_test.go
+++ b/internal/steem/provider_test.go
@@ -1,0 +1,54 @@
+package steem
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestClientImplementsProvider is a runtime mirror of the compile-time
+// `var _ Provider = (*Client)(nil)` assertion.
+func TestClientImplementsProvider(t *testing.T) {
+	var p Provider = (*Client)(nil)
+	ifaceType := reflect.TypeOf((*Provider)(nil)).Elem()
+	clientType := reflect.TypeOf(p)
+
+	for i := 0; i < ifaceType.NumMethod(); i++ {
+		want := ifaceType.Method(i)
+		if _, ok := clientType.MethodByName(want.Name); !ok {
+			t.Errorf("*steem.Client is missing Provider method %q", want.Name)
+		}
+	}
+}
+
+// TestProviderInterfaceSurface pins the exact method set of Provider so that
+// adding/removing a method is a deliberate, reviewed change.
+func TestProviderInterfaceSurface(t *testing.T) {
+	want := map[string]bool{
+		"GetBlock":                   true,
+		"GetBlocksRange":             true,
+		"GetAccounts":                true,
+		"GetContent":                 true,
+		"GetContentBatch":            true,
+		"GetDynamicGlobalProperties": true,
+		"HeadBlock":                  true,
+		"LastIrreversible":           true,
+	}
+	ifaceType := reflect.TypeOf((*Provider)(nil)).Elem()
+	got := make(map[string]bool, ifaceType.NumMethod())
+	for i := 0; i < ifaceType.NumMethod(); i++ {
+		got[ifaceType.Method(i).Name] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Provider has %d methods, test expects %d — update this test", len(got), len(want))
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("Provider is missing expected method %q", name)
+		}
+	}
+	for name := range got {
+		if !want[name] {
+			t.Errorf("Provider has unexpected method %q — update the test if intentional", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Define a `steem.Provider` interface over the Steem RPC surface and depend on it instead of the concrete `*steem.Client`. This is the KR5 prerequisite for unit-testing indexer code that hits steemd.

## Changes
- **`internal/steem/provider.go`** (new): `Provider` interface with 8 methods (GetBlock, GetBlocksRange, GetAccounts, GetContent, GetContentBatch, GetDynamicGlobalProperties, HeadBlock, LastIrreversible). Compile-time assertion `var _ Provider = (*Client)(nil)`.
- **`internal/indexer/sync.go`**: `Sync.steem` field + `NewSync` param changed from `*steem.Client` to `steem.Provider`.
- **`internal/indexer/block_processor.go`**: added `steem steem.Provider` field; `NewBlockProcessor` takes `steemProvider` param; passes it to `AccountIndexer`.
- **`internal/indexer/account_indexer.go`**: added `steem steem.Provider` field; `NewAccountIndexer` takes `steemProvider` param (for KR3 Flush).
- **`internal/steem/provider_test.go`** (new): pins the Provider method set; verifies `*Client` implements it.

`cmd/indexer/main.go` needs **no change** — `*steem.Client` implicitly satisfies the interface.

## Why
The interface boundary is what lets the upcoming CachedPost (KR2), AccountIndexer.Flush (KR3), and condenser `get_transaction` (KR6) be unit-tested with a mock rather than a live steemd node.

## Validation
- `go build` / `go vet` / `go test ./...` all green.
- Compile-time + runtime assertions confirm `*Client` satisfies `Provider`.

## Test plan
- [ ] CI green

Part of Q3 O4 / KR5. Depends on #379 (KR1 model fixes, already merged).