### PR TITLE
perf: replace get_discussion tree walk with single recursive CTE

### DIFF
--- a/hive/server/bridge_api/objects.py
+++ b/hive/server/bridge_api/objects.py
@@ -45,8 +45,10 @@ MAX_BATCH_SIZE = 1000
 async def load_posts_keyed(db, ids, truncate_body=0):
     """Given an array of post ids, returns full posts objects keyed by id."""
     # pylint: disable=too-many-locals
+    from time import perf_counter
     assert ids, 'no ids passed to load_posts_keyed'
 
+    t0 = perf_counter()
     # Optimized: Split large id lists into batches to avoid performance issues
     # with very large IN clauses (>1000 items)
     if len(ids) <= MAX_BATCH_SIZE:
@@ -59,7 +61,11 @@ async def load_posts_keyed(db, ids, truncate_body=0):
             batch_ids = ids[i:i + MAX_BATCH_SIZE]
             batch_result = await _fetch_posts_batch(db, batch_ids)
             result.extend(batch_result)
+    ms_fetch = (perf_counter() - t0) * 1000
+
+    t1 = perf_counter()
     author_map = await _query_author_map(db, result)
+    ms_author = (perf_counter() - t1) * 1000
 
     # TODO: author affiliation?
     ctx = {}
@@ -95,6 +101,7 @@ async def load_posts_keyed(db, ids, truncate_body=0):
     # matching the pre-batch behavior.
     titles = {cid: None for cid in ctx}
     roles = {cid: {} for cid in ctx}
+    t_comm = perf_counter()
     if ctx:
         all_cids = tuple(ctx.keys())
 
@@ -141,6 +148,14 @@ async def load_posts_keyed(db, ids, truncate_body=0):
     for pid in await db.query_col(sql, ids=tuple(ids)):
         if pid in posts_by_id:
             posts_by_id[pid]['stats']['is_pinned'] = True
+
+    ms_comm = (perf_counter() - t_comm) * 1000
+    ms_total = (perf_counter() - t0) * 1000
+    if ms_total > 500:
+        log.warning(
+            "[POSTS_KEYED_SLOW] ids=%d total=%.0fms "
+            "fetch=%.0fms author=%.0fms comm_roles=%.0fms",
+            len(ids), ms_total, ms_fetch, ms_author, ms_comm)
 
     return posts_by_id
 

--- a/hive/server/bridge_api/thread.py
+++ b/hive/server/bridge_api/thread.py
@@ -1,6 +1,7 @@
 """Routes then builds a get_state response object"""
 
 import logging
+from time import perf_counter
 
 from hive.server.bridge_api.objects import load_posts_keyed
 from hive.server.common.helpers import (
@@ -24,19 +25,40 @@ MAX_DEPTH = 50
 async def get_discussion(context, author, permlink):
     """Modified `get_state` thread implementation."""
     db = context['db']
+    t_total = perf_counter()
 
     author = valid_account(author)
     permlink = valid_permlink(permlink)
+
+    t = perf_counter()
     root_id = await _get_post_id(db, author, permlink)
+    ms_pid = (perf_counter() - t) * 1000
+
+    t = perf_counter()
     hide_id = await _get_author_hide_id(db, author)
+    ms_hide = (perf_counter() - t) * 1000
+
     if not root_id or hide_id:
         return {}
 
+    t = perf_counter()
     post_hide_id = await _check_posts_hide_id(db, root_id)
+    ms_phi = (perf_counter() - t) * 1000
     if post_hide_id:
         return {}
 
-    return await _load_discussion(db, root_id)
+    t = perf_counter()
+    result = await _load_discussion(db, root_id)
+    ms_load = (perf_counter() - t) * 1000
+
+    ms_all = (perf_counter() - t_total) * 1000
+    if ms_all > 1000:
+        log.warning(
+            "[DISCUSSION_SLOW] %s/%s total=%.0fms post_id=%.0fms "
+            "hide_chk=%.0fms post_hide=%.0fms load=%.0fms",
+            author, permlink, ms_all, ms_pid, ms_hide, ms_phi, ms_load)
+
+    return result
 
 async def _get_post_id(db, author, permlink):
     """Given an author/permlink, retrieve the id from db."""
@@ -96,6 +118,8 @@ async def _load_discussion(db, root_id):
     todo = [root_id]
     depth = 0
     truncated = False
+    child_ids_queries = 0
+    t_tree = perf_counter()
     while todo:
         # Bound the number of sequential _child_ids queries (one per depth).
         if depth >= MAX_DEPTH:
@@ -108,12 +132,14 @@ async def _load_discussion(db, root_id):
             todo = todo[:MAX_THREAD_POSTS - len(ids)]
             ids.extend(todo)
             rows = await _child_ids(db, todo)
+            child_ids_queries += 1
             for pid, _cids in rows:
                 tree[pid] = []
             truncated = True
             break
         ids.extend(todo)
         rows = await _child_ids(db, todo)
+        child_ids_queries += 1
         todo = []
         for pid, cids in rows:
             if cids:
@@ -126,12 +152,22 @@ async def _load_discussion(db, root_id):
             todo.extend(cids)
         depth += 1
 
+    ms_tree = (perf_counter() - t_tree) * 1000
+
     if truncated:
         log.warning("discussion %s truncated at depth=%d posts=%d",
                     root_id, depth, len(ids))
 
     # load all post objects, build ref-map
+    t_posts = perf_counter()
     posts = await load_posts_keyed(db, ids)
+    ms_posts = (perf_counter() - t_posts) * 1000
+
+    if ms_tree > 500 or ms_posts > 500:
+        log.warning(
+            "[DISCUSSION_BREAKDOWN] root_id=%d tree_walk=%.0fms(%d queries, "
+            "depth=%d posts=%d) load_posts=%.0fms",
+            root_id, ms_tree, child_ids_queries, depth, len(ids), ms_posts)
 
     # remove posts/comments from muted accounts
     rem_pids = []

--- a/hive/server/bridge_api/thread.py
+++ b/hive/server/bridge_api/thread.py
@@ -8,18 +8,49 @@ from hive.server.common.helpers import (
     return_error_info,
     valid_account,
     valid_permlink)
-from hive.server.bridge_api.cursor import hide_pids_by_ids
 
 log = logging.getLogger(__name__)
 
 # Hard caps to prevent connection-pool exhaustion on pathological threads.
-# _load_discussion walks the comment tree level by level, issuing one
-# _child_ids query per depth level. Without bounds, a 1000+ comment / 50+
-# depth thread can hold a connection for an unbounded time and starve the
-# pool. MAX_DEPTH bounds the number of sequential queries; MAX_THREAD_POSTS
-# bounds the total number of posts loaded into memory.
+# _load_discussion walks the comment tree with a single recursive CTE query;
+# MAX_DEPTH bounds recursion depth and MAX_THREAD_POSTS bounds the total
+# number of posts loaded into memory (LIMIT inside the CTE).
 MAX_THREAD_POSTS = 500
 MAX_DEPTH = 50
+
+# Fetch the whole comment subtree of a root post in ONE DB round-trip.
+# Previously this was a level-by-level BFS issuing one _child_ids query per
+# depth level (observed 500-1300ms for depth 4-10 threads, each query adding
+# a pool acquire + parse + round-trip). Hidden authors (list_type='3') and
+# hidden posts (list_type='1') are filtered inside the recursion so their
+# subtrees are never traversed. ORDER BY depth,id keeps BFS order so
+# LIMIT truncation matches the old level-by-level semantics.
+_DISCUSSION_TREE_SQL = """
+    WITH RECURSIVE tree AS (
+        SELECT id, parent_id, 0 AS depth
+        FROM hive_posts
+        WHERE id = :root_id
+
+        UNION ALL
+
+        SELECT p.id, p.parent_id, t.depth + 1
+        FROM hive_posts p
+        INNER JOIN tree t ON p.parent_id = t.id
+        LEFT JOIN hive_posts_status s3
+            ON s3.list_type = '3' AND s3.author = p.author
+        LEFT JOIN hive_posts_status s1
+            ON s1.list_type = '1' AND s1.post_id = p.id
+        WHERE p.is_deleted = '0'
+          AND s3.id IS NULL
+          AND s1.id IS NULL
+          AND t.depth < :max_depth
+    )
+    SELECT id, parent_id, depth
+    FROM tree
+    WHERE parent_id IS NOT NULL
+    ORDER BY depth, id
+    LIMIT :max_posts
+"""
 
 @return_error_info
 async def get_discussion(context, author, permlink):
@@ -93,70 +124,34 @@ async def _check_posts_hide_id(db, post_id):
 def _ref(post):
     return post['author'] + '/' + post['permlink']
 
-async def _child_ids(db, parent_ids):
-    """Load child ids for multuple parent ids."""
-    # Optimized: Use LEFT JOIN instead of NOT EXISTS to improve performance
-    # This avoids executing a subquery for each row and better utilizes indexes
-    sql = """
-        SELECT p.parent_id as parent_id, array_agg(p.id) as child_ids
-        FROM hive_posts p
-        LEFT JOIN hive_posts_status s ON s.list_type = '3' AND s.author = p.author
-        WHERE p.parent_id IN :ids
-        AND p.is_deleted = '0'
-        AND s.id IS NULL
-        GROUP BY p.parent_id
-    """
-    rows = await db.query_all(sql, ids=tuple(parent_ids),
-        cache_key="_child_ids_" + "_".join(map(str, parent_ids)), cache_ttl=120)
-    return [[row['parent_id'], row['child_ids']] for row in rows]
-
 async def _load_discussion(db, root_id):
-    """Load a full discussion thread."""
-    # build `ids` list and `tree` map
-    ids = []
-    tree = {}
-    todo = [root_id]
-    depth = 0
-    truncated = False
-    child_ids_queries = 0
+    """Load a full discussion thread in a single recursive CTE query."""
     t_tree = perf_counter()
-    while todo:
-        # Bound the number of sequential _child_ids queries (one per depth).
-        if depth >= MAX_DEPTH:
-            truncated = True
-            break
-        # Bound total posts collected so a wide thread cannot exhaust memory
-        # or hold connections for too long. If this batch would exceed the cap,
-        # take only what fits, resolve their (empty) child mapping, and stop.
-        if len(ids) + len(todo) > MAX_THREAD_POSTS:
-            todo = todo[:MAX_THREAD_POSTS - len(ids)]
-            ids.extend(todo)
-            rows = await _child_ids(db, todo)
-            child_ids_queries += 1
-            for pid, _cids in rows:
-                tree[pid] = []
-            truncated = True
-            break
-        ids.extend(todo)
-        rows = await _child_ids(db, todo)
-        child_ids_queries += 1
-        todo = []
-        for pid, cids in rows:
-            if cids:
-                hide_pids = await hide_pids_by_ids(db, cids)
-                for hide_pid in hide_pids:
-                    if hide_pid in cids:
-                        cids.remove(hide_pid)
-
-            tree[pid] = cids
-            todo.extend(cids)
-        depth += 1
-
+    rows = await db.query_all(
+        _DISCUSSION_TREE_SQL,
+        root_id=root_id,
+        max_depth=MAX_DEPTH,
+        max_posts=MAX_THREAD_POSTS,
+        cache_key="discussion_tree_%d" % root_id,
+        cache_ttl=120)
     ms_tree = (perf_counter() - t_tree) * 1000
+
+    # build `ids` list and `tree` map (rows come in BFS order: depth, id)
+    ids = [root_id]
+    tree = {}
+    max_depth_seen = 0
+    for row in rows:
+        pid, cid, depth = row['parent_id'], row['id'], row['depth']
+        tree.setdefault(pid, []).append(cid)
+        ids.append(cid)
+        if depth > max_depth_seen:
+            max_depth_seen = depth
+    # LIMIT hit (rows capped) or recursion hit MAX_DEPTH => truncated
+    truncated = (len(ids) > MAX_THREAD_POSTS) or (max_depth_seen >= MAX_DEPTH)
 
     if truncated:
         log.warning("discussion %s truncated at depth=%d posts=%d",
-                    root_id, depth, len(ids))
+                    root_id, max_depth_seen, len(ids))
 
     # load all post objects, build ref-map
     t_posts = perf_counter()
@@ -167,7 +162,7 @@ async def _load_discussion(db, root_id):
         log.warning(
             "[DISCUSSION_BREAKDOWN] root_id=%d tree_walk=%.0fms(%d queries, "
             "depth=%d posts=%d) load_posts=%.0fms",
-            root_id, ms_tree, child_ids_queries, depth, len(ids), ms_posts)
+            root_id, ms_tree, 1, max_depth_seen, len(ids), ms_posts)
 
     # remove posts/comments from muted accounts
     rem_pids = []

--- a/hive/server/db.py
+++ b/hive/server/db.py
@@ -29,7 +29,12 @@ def sqltimer(function):
     async def _wrapper(*args, **kwargs):
         start = perf()
         result = await function(*args, **kwargs)
-        Stats.log_db(args[1], perf() - start)
+        elapsed = perf() - start
+        Stats.log_db(args[1], elapsed)
+        if elapsed > 3.0:
+            log.warning(
+                "[DB_SLOW] %.3fs %s",
+                elapsed, args[1][:200])
         return result
     return _wrapper
 

--- a/hive/server/db.py
+++ b/hive/server/db.py
@@ -32,9 +32,12 @@ def sqltimer(function):
         elapsed = perf() - start
         Stats.log_db(args[1], elapsed)
         if elapsed > 3.0:
+            # Collapse newlines/whitespace: multi-line SQL would otherwise be
+            # truncated at the first line break by syslog (observed in prod:
+            # DB_SLOW entries with an empty SQL body).
             log.warning(
                 "[DB_SLOW] %.3fs %s",
-                elapsed, args[1][:200])
+                elapsed, ' '.join(args[1].split())[:200])
         return result
     return _wrapper
 

--- a/tests/bridge_thread/test_bridge_thread.py
+++ b/tests/bridge_thread/test_bridge_thread.py
@@ -7,12 +7,14 @@ under tests/bridge_thread/ (rather than tests/server/) on purpose: the
 tests/server/__init__.py eagerly opens a real DB connection, which would
 prevent these no-DB tests from running here.
 
-They exercise the connection-pool-exhaustion safeguards added to
-`_load_discussion` (MAX_DEPTH / MAX_THREAD_POSTS caps) and verify the
-hide-id lookups forward their cache_key/cache_ttl to the db layer.
+They exercise the new single-recursive-CTE implementation of
+`_load_discussion` (replaces the old level-by-level BFS): exactly one
+query_all call with the right cache params, correct tree/ids assembly in
+BFS order, and the MAX_DEPTH / MAX_THREAD_POSTS truncation safeguards.
+The hide-id lookups forward their cache_key/cache_ttl to the db layer.
 
-A fake async db records the calls it receives so assertions can inspect how
-many `_child_ids`-equivalent queries ran and what cache params were passed.
+A fake async db records the calls it receives so assertions can inspect
+query parameters without a real database.
 """
 
 # pylint: disable=protected-access,missing-docstring
@@ -36,8 +38,8 @@ import pytest  # noqa: E402
 class FakeAsyncDb:
     """Records calls and returns canned results for the methods thread.py uses.
 
-    `query_one` results are configured per-cache_key. `query_all` results are
-    configured per-call-count to simulate walking a comment tree level by level.
+    `query_one` results are configured per-cache_key. `query_all` returns the
+    first element of `query_all_seq` (the single CTE call) then empty lists.
     """
 
     def __init__(self, query_all_seq=None, query_one_map=None):
@@ -68,86 +70,136 @@ def _run(coro):
         loop.close()
 
 
-def _install_load_posts_keyed(monkeypatch, posts=None):
+def _install_load_posts_keyed(monkeypatch, posts=None, seen_ids=None):
     """Stub out load_posts_keyed so _load_discussion needs no real post data."""
 
-    async def _stub(_db, _ids, _truncate_body=0):
+    async def _stub(_db, ids, _truncate_body=0):
+        if seen_ids is not None:
+            seen_ids['ids'] = list(ids)
         return posts or {}
 
     monkeypatch.setattr(thread, 'load_posts_keyed', _stub)
 
 
-def _install_hide_pids_by_ids(monkeypatch, hidden=None):
-    """Stub out hide_pids_by_ids so no real filtering happens."""
-    hidden = hidden or set()
-
-    async def _stub(_db, cids):
-        return [pid for pid in cids if pid in hidden]
-
-    monkeypatch.setattr(thread, 'hide_pids_by_ids', _stub)
+def _cte_rows(*tuples):
+    """Build query_all rows from (id, parent_id, depth) tuples."""
+    return [{'parent_id': p, 'id': i, 'depth': d} for (i, p, d) in tuples]
 
 
-def _child_ids_rows(parent_to_children):
-    """Build a query_all result list (one batch) from a {parent: [children]} map."""
-    return [{
-        'parent_id': pid,
-        'child_ids': cids
-    } for pid, cids in parent_to_children.items()]
+def _minimal_posts(ids):
+    """Build a posts dict (id -> post) with non-hidden stats."""
+    return {
+        pid: {'author': 'a%d' % pid, 'permlink': 'p%d' % pid,
+              'stats': {'hide': False}}
+        for pid in ids
+    }
 
 
-def test_load_discussion_respects_max_depth(monkeypatch):
-    """A chain deeper than MAX_DEPTH must stop after MAX_DEPTH _child_ids calls.
+def test_load_discussion_issues_single_cte_query(monkeypatch):
+    """_load_discussion must issue exactly ONE query_all (the recursive CTE).
 
-    Build an infinitely deep single-child chain (1 -> 2 -> 3 -> ...). Each
-    query_all call returns the next level. Without the cap this loops forever.
+    The old implementation walked the tree level by level with one
+    _child_ids query per depth; the new one fetches the whole subtree in a
+    single round-trip, so exactly one query_all call is expected.
     """
     _install_load_posts_keyed(monkeypatch)
-    _install_hide_pids_by_ids(monkeypatch)
 
-    call_count = {'n': 0}
-
-    def next_level():
-        call_count['n'] += 1
-        parent = call_count['n']  # level N's parent is N
-        return _child_ids_rows({parent: [parent + 1]})
-
-    db = FakeAsyncDb()
-    # Provide MAX_DEPTH+5 levels so we can prove it stops at the cap rather
-    # than running out of data.
-    db._query_all_seq = [next_level() for _ in range(MAX_DEPTH + 5)]
-
+    db = FakeAsyncDb(query_all_seq=[
+        _cte_rows((2, 1, 1), (3, 1, 1), (4, 2, 2))
+    ])
     _run(_load_discussion(db, 1))
 
-    # One _child_ids query per depth level, capped at MAX_DEPTH.
-    assert len(db.query_all_calls) == MAX_DEPTH
-
-
-def test_load_discussion_respects_max_thread_posts(monkeypatch):
-    """A very wide thread must be truncated at MAX_THREAD_POSTS total posts."""
-    _install_load_posts_keyed(monkeypatch)
-    _install_hide_pids_by_ids(monkeypatch)
-
-    # Level 1: root has 600 children (already > MAX_THREAD_POSTS=500).
-    wide_children = list(range(1000, 1600))
-    db = FakeAsyncDb(query_all_seq=[_child_ids_rows({1: wide_children})])
-
-    _run(_load_discussion(db, 1))
-
-    # Root level resolves, then the over-cap batch is truncated to fit.
-    assert len(db.query_all_calls) == 2
-    # The second call's parent_ids length is what got added: 500 - 1 = 499.
-    second_call_ids = db.query_all_calls[1]['kwargs']['ids']
-    assert len(second_call_ids) == MAX_THREAD_POSTS - 1
-
-
-def test_load_discussion_terminates_on_leaf(monkeypatch):
-    """A root with no children completes in a single _child_ids call."""
-    _install_load_posts_keyed(monkeypatch)
-    _install_hide_pids_by_ids(monkeypatch)
-
-    db = FakeAsyncDb(query_all_seq=[_child_ids_rows({1: []})])
-    _run(_load_discussion(db, 1))
     assert len(db.query_all_calls) == 1
+    call = db.query_all_calls[0]
+    assert call['kwargs']['root_id'] == 1
+    assert call['kwargs']['max_depth'] == MAX_DEPTH
+    assert call['kwargs']['max_posts'] == MAX_THREAD_POSTS
+    assert call['kwargs']['cache_key'] == 'discussion_tree_1'
+    assert call['kwargs']['cache_ttl'] == 120
+
+
+def test_load_discussion_builds_tree_in_bfs_order(monkeypatch):
+    """Root first, then children by (depth, id); replies wired per parent."""
+    ids = [1, 2, 3, 4]
+    posts = _minimal_posts(ids)
+    _install_load_posts_keyed(monkeypatch, posts=posts, seen_ids={})
+
+    db = FakeAsyncDb(query_all_seq=[
+        _cte_rows((2, 1, 1), (3, 1, 1), (4, 2, 2))
+    ])
+    result = _run(_load_discussion(db, 1))
+
+    # ids passed to load_posts_keyed: root first, then BFS order
+    assert set(result.keys()) == {'a1/p1', 'a2/p2', 'a3/p3', 'a4/p4'}
+    assert result['a1/p1']['replies'] == ['a2/p2', 'a3/p3']
+    assert result['a2/p2']['replies'] == ['a4/p4']
+    # leaf posts have no 'replies' key (only set when pid in tree)
+    assert 'replies' not in result['a3/p3']
+    assert 'replies' not in result['a4/p4']
+
+
+def test_load_discussion_single_child_chain(monkeypatch):
+    """Deep chain 1->2->3->4 completes with one query; all ids loaded."""
+    _install_load_posts_keyed(monkeypatch, posts=_minimal_posts([1, 2, 3, 4]))
+
+    db = FakeAsyncDb(query_all_seq=[
+        _cte_rows((2, 1, 1), (3, 2, 2), (4, 3, 3))
+    ])
+    _run(_load_discussion(db, 1))
+
+    assert len(db.query_all_calls) == 1
+
+
+def test_load_discussion_truncated_when_limit_hit(monkeypatch):
+    """If the CTE returned more rows than MAX_THREAD_POSTS, mark truncated.
+
+    (The SQL LIMIT normally prevents this; the Python guard is a belt-and-
+    braces check that len(ids) > MAX_THREAD_POSTS is treated as truncation.)
+    """
+    warnings = []
+    monkeypatch.setattr(thread.log, 'warning',
+                        lambda *a, **k: warnings.append(a))
+    _install_load_posts_keyed(monkeypatch)
+
+    # Root + MAX_THREAD_POSTS + 5 children -> ids length exceeds the cap.
+    extra = [((i, 1, 1)) for i in range(2, MAX_THREAD_POSTS + 7)]
+    db = FakeAsyncDb(query_all_seq=[_cte_rows(*extra)])
+    _run(_load_discussion(db, 1))
+
+    assert any('truncated' in str(w) for w in warnings)
+
+
+def test_load_discussion_truncated_when_depth_cap_hit(monkeypatch):
+    """max_depth_seen reaching MAX_DEPTH marks the walk truncated."""
+    warnings = []
+    monkeypatch.setattr(thread.log, 'warning',
+                        lambda *a, **k: warnings.append(a))
+    _install_load_posts_keyed(monkeypatch)
+
+    # A row whose depth equals MAX_DEPTH => recursion hit the cap.
+    db = FakeAsyncDb(query_all_seq=[
+        _cte_rows((2, 1, MAX_DEPTH))
+    ])
+    _run(_load_discussion(db, 1))
+
+    assert any('truncated' in str(w) for w in warnings)
+
+
+def test_load_discussion_leaf_terminates(monkeypatch):
+    """Root with no children: single CTE call, root-only ids, no truncation."""
+    warnings = []
+    monkeypatch.setattr(thread.log, 'warning',
+                        lambda *a, **k: warnings.append(a))
+    seen = {}
+    _install_load_posts_keyed(monkeypatch, posts=_minimal_posts([1]),
+                              seen_ids=seen)
+
+    db = FakeAsyncDb(query_all_seq=[_cte_rows()])  # empty tree below root
+    _run(_load_discussion(db, 1))
+
+    assert len(db.query_all_calls) == 1
+    assert seen['ids'] == [1]
+    assert not any('truncated' in str(w) for w in warnings)
 
 
 def test_get_post_id_forwards_cache_params():


### PR DESCRIPTION
## Summary

Fixes two issues found while validating the `debug-get-discussion-tracing` image in production:

### 1. `get_discussion` tree walk: level-by-level BFS → single recursive CTE

The old `_load_discussion` walked the comment tree one depth level at a time, issuing one `_child_ids` query per level. Production logs showed **500-1300ms** for depth 4-10 threads — each level adds a pool acquire + parse + round-trip.

Replaced with a single `WITH RECURSIVE` query fetching the whole subtree in **one DB round-trip**:
- Hidden authors (`list_type='3'`) and hidden posts (`list_type='1'`) are filtered **inside the recursion**, so their subtrees are never traversed
- `MAX_DEPTH` / `MAX_THREAD_POSTS` caps preserved (`LIMIT` inside the CTE), BFS ordering kept so truncation semantics match the old implementation
- Whole tree cached under `discussion_tree_<root_id>` (120s TTL), replacing the per-level `_child_ids_*` cache

### 2. `[DB_SLOW]` log: SQL body was empty in production

`db.py` logged `args[1][:200]` directly — multi-line SQL starts with `\n`, so syslog truncated every entry after the timestamp. Collapse whitespace before logging (same as `_normalize_sql` in stats.py).

## Verification

- `tests/bridge_thread/`: **9/9 passed** (rewritten for single-CTE semantics)
- CTE SQL tested against real Postgres 16 (hidden-post filtering, depth cap, post cap, deep-chain BFS order)
- Wide-thread perf: 5000-child tree resolves in **27ms** single query (vs ~1s level-by-level)
- `LIMIT :max_posts` binding verified with production SQLAlchemy 1.4.54
- `tests/utils`: 3 pre-existing failures unrelated to this change (confirmed via git stash baseline)

## Notes

- Debug timing logs (`DISCUSSION_SLOW` / `DISCUSSION_BREAKDOWN` / `POSTS_KEYED_SLOW` / `DB_SLOW`) remain in this branch for continued validation
- Go rewrite (`internal/api/bridge/post.go`) still has `TODO: Fetch all replies recursively` — this change is the reference implementation for that