### PR TITLE
fix: accept string-form version in posting_json_metadata

### DIFF
--- a/hive/utils/account.py
+++ b/hive/utils/account.py
@@ -11,7 +11,14 @@ def safe_profile_metadata(account):
         # read from posting_json_metadata, if version==2
         prof = json.loads(account['posting_json_metadata'])['profile']
         assert isinstance(prof, dict)
-        assert 'version' in prof and prof['version'] == 2
+        # The "version" field is serialized inconsistently across Steem clients:
+        # the official condenser writes a JSON number (2), but some third-party
+        # clients write a JSON string ("2").  Accept both forms so that accounts
+        # created/updated by third-party clients are not silently dropped to
+        # empty profile data.
+        # TODO: when a new profile version is introduced, standardize on a single
+        # canonical type (JSON number) and migrate legacy string-form accounts.
+        assert 'version' in prof and prof['version'] in (2, '2')
     except Exception:
         try:
             # fallback to json_metadata

--- a/tests/utils/test_utils_account.py
+++ b/tests/utils/test_utils_account.py
@@ -19,6 +19,27 @@ def test_valid_account():
     for key, safe_value in safe_profile.items():
         assert raw_profile[key] == safe_value
 
+def test_string_version_account():
+    # Some third-party Steem clients serialize "version" as a JSON string ("2")
+    # instead of a number (2).  Such accounts should still be parsed correctly.
+    raw_profile = dict(
+        name='Test User',
+        about='Hello world',
+        location='Earth',
+        website='https://example.com/',
+        cover_image='https://example.com/cover.jpg',
+        profile_image='https://example.com/avatar.jpg',
+        version='2',
+    )
+    account = {'name': 'foo', 'json_metadata': '{}',
+               'posting_json_metadata': json.dumps(dict(profile=raw_profile))}
+
+    safe_profile = safe_profile_metadata(account)
+    assert safe_profile['name'] == 'Test User'
+    assert safe_profile['about'] == 'Hello world'
+    assert safe_profile['profile_image'] == 'https://example.com/avatar.jpg'
+    assert safe_profile['cover_image'] == 'https://example.com/cover.jpg'
+
 def test_invalid_account():
     raw_profile = dict(
         name='NameIsTooBigByOneChar',


### PR DESCRIPTION
## Problem

The `version` field in `posting_json_metadata` → `profile` is serialized inconsistently across Steem clients:

| Source | `version` value | Type |
|---|---|---|
| Official condenser (`Settings.jsx:169`) | `2` | JSON number |
| Some third-party clients | `"2"` | JSON string |

The strict equality check at `hive/utils/account.py:14` only accepted the numeric form:

```python
assert 'version' in prof and prof['version'] == 2
```

A string `"2"` fails `"2" == 2` in Python → assertion fails → falls through to `json_metadata` fallback → if that is also empty/invalid → `prof = {}` → **all profile fields (`profile_image`, `cover_image`, `name`, `about`, etc.) are stored as empty strings in `hive_accounts`**.

### Impact

Since `safe_profile_metadata()` runs during indexing and the result is persisted to the `hive_accounts` DB table, affected accounts have empty profile data in the database. The condenser frontend calls `bridge.get_profile`, reads these empty strings, and:
- **Avatar hidden**: `Userpic` component `hideIfDefault` logic sees empty `profile_image` → hides the avatar entirely
- **Banner hidden**: `UserProfileHeader` sees empty `cover_image` → no banner background rendered

Real-world example: user `bijoy1` (version `"2"`, empty `json_metadata`) — both avatar and banner invisible on steemit.com.

### Note on data flow

This function executes once during indexer account sync. The parsed result is written to the `hive_accounts` table (columns `profile_image`, `cover_image`, etc.). After this fix is deployed, affected accounts will be corrected on their next account refresh cycle.

## Fix

Change `prof['version'] == 2` to `prof['version'] in (2, '2')` — accepts both numeric and string forms.

Added a detailed comment explaining the inconsistency and a `TODO` to standardize on a single canonical type (JSON number) when a new version is introduced.

## Test

Added `test_string_version_account` covering the string-form `version` case. All 3 tests pass:

```
tests/utils/test_utils_account.py::test_valid_account PASSED
tests/utils/test_utils_account.py::test_string_version_account PASSED
tests/utils/test_utils_account.py::test_invalid_account PASSED
```
