### PR TITLE
fix(api): replace self-delegating stubs with explicit not-implemented errors

### DIFF
--- a/internal/api/bridge/ranked.go
+++ b/internal/api/bridge/ranked.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/steemit/hivemind/internal/api/condenser"
 	"github.com/steemit/hivemind/internal/cache"
 	"github.com/steemit/hivemind/internal/db"
-	"github.com/steemit/hivemind/internal/api/condenser"
 )
 
 // RankedAPI provides ranked posts API methods
@@ -72,7 +72,7 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 		tag,
 	}
 	cacheKey := cache.HashKey(cacheKeyParts...)
-	
+
 	// Check cache
 	if r.cache != nil {
 		var cachedResult []interface{}
@@ -83,13 +83,13 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 
 	// Map sort types
 	sortMap := map[string]string{
-		"trending": "trending",
-		"hot":      "hot",
-		"created":  "created",
-		"promoted": "promoted",
-		"payout":   "payout",
+		"trending":        "trending",
+		"hot":             "hot",
+		"created":         "created",
+		"promoted":        "promoted",
+		"payout":          "payout",
 		"payout_comments": "payout_comments",
-		"muted":    "muted", // Special case
+		"muted":           "muted", // Special case
 	}
 
 	querySort, ok := sortMap[sort]
@@ -187,8 +187,10 @@ func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (i
 		}
 		return result, nil
 	case "feed":
-		// Similar to blog but personalized
-		return r.GetAccountPosts(ctx, params) // TODO: Implement feed logic
+		// TODO: Implement personalized feed (follows join feed_cache, see
+		// legacy pids_by_feed_with_reblog). Must NOT delegate to self with
+		// unchanged params — that is infinite recursion (stack overflow).
+		return nil, fmt.Errorf("feed sort is not implemented")
 	case "posts":
 		// Author's posts only (no reblogs)
 		// TODO: Implement
@@ -236,4 +238,3 @@ func (r *RankedAPI) GetTrendingTopics(ctx *gin.Context, params json.RawMessage) 
 	// For now, return empty result
 	return []interface{}{}, nil
 }
-

--- a/internal/api/bridge/ranked_test.go
+++ b/internal/api/bridge/ranked_test.go
@@ -1,0 +1,61 @@
+package bridge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestGetAccountPosts_FeedSortNoRecursion is a regression test for the
+// 2026-08-16 security audit finding: `case "feed"` used to delegate to
+// GetAccountPosts with unchanged params — infinite recursion, stack overflow,
+// uncatchable by gin.Recovery(), crashing the whole process on a single
+// unauthenticated request.
+//
+// The feed branch must return an explicit error BEFORE any DB access, so this
+// test uses a zero-value RankedAPI (nil cursor/repo) and asserts we get an
+// error, not a crash.
+func TestGetAccountPosts_FeedSortNoRecursion(t *testing.T) {
+	r := &RankedAPI{}
+	gin.SetMode(gin.TestMode)
+	ctx := &gin.Context{}
+
+	params, _ := json.Marshal(map[string]interface{}{
+		"sort":    "feed",
+		"account": "alice",
+	})
+
+	result, err := r.GetAccountPosts(ctx, params)
+
+	if err == nil {
+		t.Fatalf("feed sort must return an explicit not-implemented error, got result=%v", result)
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should mention 'not implemented', got: %v", err)
+	}
+}
+
+// TestGetAccountPosts_UnimplementedSorts verifies the other stub sorts return
+// explicit empty results (their documented placeholder shape) rather than
+// delegating anywhere.
+func TestGetAccountPosts_UnimplementedSorts(t *testing.T) {
+	r := &RankedAPI{}
+	gin.SetMode(gin.TestMode)
+	ctx := &gin.Context{}
+
+	for _, sort := range []string{"posts", "comments", "replies"} {
+		params, _ := json.Marshal(map[string]interface{}{
+			"sort":    sort,
+			"account": "alice",
+		})
+		result, err := r.GetAccountPosts(ctx, params)
+		if err != nil {
+			t.Errorf("sort %q returned error %v (expected empty placeholder)", sort, err)
+		}
+		if result == nil {
+			t.Errorf("sort %q returned nil (expected empty slice)", sort)
+		}
+	}
+}

--- a/internal/api/condenser/blog.go
+++ b/internal/api/condenser/blog.go
@@ -73,8 +73,8 @@ func (b *BlogAPI) GetBlog(ctx *gin.Context, params json.RawMessage) (interface{}
 	result := make([]interface{}, len(ids))
 	for i, id := range ids {
 		result[i] = map[string]interface{}{
-			"blog":      account,
-			"entry_id":  startEntryID + int64(i),
+			"blog":     account,
+			"entry_id": startEntryID + int64(i),
 			"comment": map[string]interface{}{
 				"id": id,
 			},
@@ -86,7 +86,8 @@ func (b *BlogAPI) GetBlog(ctx *gin.Context, params json.RawMessage) (interface{}
 
 // GetBlogEntries handles condenser_api.get_blog_entries
 func (b *BlogAPI) GetBlogEntries(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Similar to get_blog but returns minimal post references
-	return b.GetBlog(ctx, params)
+	// TODO: Implement (legacy returns a LIGHTWEIGHT shape: {blog, entry_id,
+	// author, permlink, reblog_on} — delegating to GetBlog would return full
+	// post objects, which is the wrong response shape).
+	return nil, fmt.Errorf("not implemented")
 }
-

--- a/internal/api/condenser/discussions.go
+++ b/internal/api/condenser/discussions.go
@@ -12,8 +12,8 @@ import (
 
 // DiscussionsAPI provides discussion query API methods
 type DiscussionsAPI struct {
-	repo      *db.Repository
-	cursor    *Cursor
+	repo       *db.Repository
+	cursor     *Cursor
 	postLoader *objects.PostLoader
 }
 
@@ -168,8 +168,8 @@ func (d *DiscussionsAPI) GetDiscussionsByBlog(ctx *gin.Context, params json.RawM
 
 // GetDiscussionsByFeed handles condenser_api.get_discussions_by_feed
 func (d *DiscussionsAPI) GetDiscussionsByFeed(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Feed is similar to blog but includes posts from followed accounts
-	// For now, use blog implementation
-	return d.GetDiscussionsByBlog(ctx, params)
+	// TODO: Implement personalized feed (follows join feed_cache, see legacy
+	// pids_by_feed_with_reblog). Must NOT silently return blog results —
+	// feed and blog are different result sets.
+	return nil, fmt.Errorf("not implemented")
 }
-

--- a/internal/api/hive/public.go
+++ b/internal/api/hive/public.go
@@ -46,13 +46,13 @@ func (p *PublicAPI) GetAccount(ctx *gin.Context, params json.RawMessage) (interf
 	_ = observer
 
 	return map[string]interface{}{
-		"id":          account.ID,
-		"name":        account.Name,
+		"id":           account.ID,
+		"name":         account.Name,
 		"display_name": account.DisplayName.String,
-		"about":       account.About.String,
-		"reputation":  account.Reputation,
-		"followers":   account.Followers,
-		"following":   account.Following,
+		"about":        account.About.String,
+		"reputation":   account.Reputation,
+		"followers":    account.Followers,
+		"following":    account.Following,
 	}, nil
 }
 
@@ -127,8 +127,10 @@ func (p *PublicAPI) ListFollowers(ctx *gin.Context, params json.RawMessage) (int
 
 // ListFollowing handles hive_api.list_following
 func (p *PublicAPI) ListFollowing(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Similar to ListFollowers but reversed
-	return p.ListFollowers(ctx, params)
+	// TODO: Implement (query hive_follows in the following direction).
+	// Must NOT delegate to ListFollowers — different semantics, would return
+	// wrong data.
+	return nil, fmt.Errorf("not implemented")
 }
 
 // ListAllMuted handles hive_api.list_all_muted
@@ -175,13 +177,14 @@ func (p *PublicAPI) ListAccountBlog(ctx *gin.Context, params json.RawMessage) (i
 
 // ListAccountPosts handles hive_api.list_account_posts
 func (p *PublicAPI) ListAccountPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Similar to ListAccountBlog but only posts (no reblogs)
-	return p.ListAccountBlog(ctx, params)
+	// TODO: Implement (author's own posts only, no reblogs).
+	// Must NOT delegate to ListAccountBlog — different semantics.
+	return nil, fmt.Errorf("not implemented")
 }
 
 // ListAccountFeed handles hive_api.list_account_feed
 func (p *PublicAPI) ListAccountFeed(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Similar to ListAccountBlog but personalized feed
-	return p.ListAccountBlog(ctx, params)
+	// TODO: Implement (personalized feed from follows).
+	// Must NOT delegate to ListAccountBlog — different semantics.
+	return nil, fmt.Errorf("not implemented")
 }
-


### PR DESCRIPTION
## Summary

Security fix from the **2026-08-16 audit** (documented in AGENTS.md). Six handler stubs delegated to themselves or sibling handlers with unchanged/mismatched params — the worst case was a crash-the-process infinite recursion reachable by a single unauthenticated request.

## The critical bug

`bridge/ranked.go` `GetAccountPosts` case `"feed"`:
```go
return r.GetAccountPosts(ctx, params) // params unchanged -> sort stays "feed" -> infinite recursion
```
Go stack overflow is a **runtime fatal error** — `gin.Recovery()` cannot catch it. One request with `{"sort": "feed", "account": "x"}` killed the entire API server process.

## All six sites fixed

| Handler | Was | Problem |
|---------|-----|---------|
| `bridge` GetAccountPosts(feed) | → **itself** | 🔴 infinite recursion, process crash |
| `hive` ListFollowing | → ListFollowers | wrong direction (followers as following) |
| `hive` ListAccountPosts | → ListAccountBlog | different result set served silently |
| `hive` ListAccountFeed | → ListAccountBlog | same |
| `condenser` GetDiscussionsByFeed | → ByBlog | blog results as personalized feed |
| `condenser` GetBlogEntries | → GetBlog | full post objects vs legacy lightweight shape |

All now return explicit `not implemented` errors per the AGENTS.md placeholder policy — this class of bug is structurally impossible under the policy.

## Regression test

`TestGetAccountPosts_FeedSortNoRecursion`: calls feed sort with a **zero-value RankedAPI** (nil cursor/repo) and asserts an error returns — the branch errors before any DB access. Under the old code this call would stack-overflow the test binary.

## Validation
- AGENTS.md self-check grep: clean (no self-delegation patterns remain)
- `go build` / `go vet` / `go test ./...` all green