### PR TITLE
feat(indexer): port Mutes singleton and normalize utilities (PR#6a)

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -49,6 +49,10 @@ func main() {
 	}
 	defer database.Close()
 
+	// Install the shared mutes list (irredeemables) used by CachedPost
+	// notifications (PR#6d). Empty URL = disabled list.
+	steem.SetSharedMutes(steem.NewMutes(cfg.Steem.MutedAccountsURL))
+
 	// Run schema migrations before indexing.
 	//
 	// For a NEW database, forceVersion=0 runs the baseline migration (0001)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steemit/hivemind/internal/cache"
 	"github.com/steemit/hivemind/internal/db"
 	"github.com/steemit/hivemind/internal/middleware"
+	"github.com/steemit/hivemind/internal/steem"
 	"github.com/steemit/hivemind/pkg/config"
 	"github.com/steemit/hivemind/pkg/logging"
 	"github.com/steemit/hivemind/pkg/telemetry"
@@ -45,6 +46,10 @@ func main() {
 		logger.Fatal("Failed to initialize telemetry", zap.Error(err))
 	}
 	defer telemetryShutdown()
+
+	// Install the shared mutes list (irredeemables) used by API object
+	// builders (stats.hide/blacklists). Empty URL = disabled list.
+	steem.SetSharedMutes(steem.NewMutes(cfg.Steem.MutedAccountsURL))
 
 	// Initialize database
 	database, err := db.New(&cfg.Database, cfg.Logging.Level)

--- a/internal/indexer/normalize.go
+++ b/internal/indexer/normalize.go
@@ -1,0 +1,359 @@
+package indexer
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Port of hive/utils/normalize.py (legacy reference for CachedPost scoring
+// and account flush). Function-level behavior is kept faithful, including
+// quirks (e.g. repLog10's string-based log10 and trunc's '...' penalty).
+// int_log_level is intentionally not ported (Python logging specific).
+
+// NAIMap maps steemd NAI asset identifiers to asset symbols.
+// Mirrors legacy NAI_MAP (normalize.py:10).
+var NAIMap = map[string]string{
+	"@@000000013": "SBD",
+	"@@000000021": "STEEM",
+	"@@000000037": "VESTS",
+}
+
+// assetPrecision is the display precision per asset (legacy_amount, py:62).
+var assetPrecision = map[string]int{"SBD": 3, "STEEM": 3, "VESTS": 6}
+
+// VestsAmount returns the numeric value, asserting units are VESTS.
+func VestsAmount(value interface{}) (float64, error) {
+	return parseAmountUnit(value, "VESTS")
+}
+
+// SteemAmount returns the numeric value, asserting units are STEEM.
+func SteemAmount(value interface{}) (float64, error) {
+	return parseAmountUnit(value, "STEEM")
+}
+
+// SBDAmount returns the numeric value, asserting units are SBD.
+func SBDAmount(value interface{}) (float64, error) {
+	return parseAmountUnit(value, "SBD")
+}
+
+// ParseAmount parses a steemd-style amount/asset value and returns
+// (decimal, unit). Accepts three input shapes, mirroring legacy
+// parse_amount (normalize.py:28):
+//   - string:  "123.500 SBD" (legacy format)
+//   - list:    [satoshis, precision, nai] (appbase format)
+//   - object:  {amount, precision, nai}
+func ParseAmount(value interface{}) (float64, string, error) {
+	switch v := value.(type) {
+	case string:
+		raw, unit, found := strings.Cut(v, " ")
+		if !found {
+			return 0, "", fmt.Errorf("invalid amount string %q", v)
+		}
+		amt, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return 0, "", fmt.Errorf("invalid amount %q: %w", raw, err)
+		}
+		return amt, unit, nil
+	case []interface{}:
+		if len(v) != 3 {
+			return 0, "", fmt.Errorf("invalid amount array %v", v)
+		}
+		return naiAmount(v[0], v[1], v[2])
+	case map[string]interface{}:
+		return naiAmount(v["amount"], v["precision"], v["nai"])
+	case json.Number:
+		return 0, "", fmt.Errorf("bare number is not a steemd amount: %v", v)
+	default:
+		return 0, "", fmt.Errorf("invalid input amount %#v", value)
+	}
+}
+
+func parseAmountUnit(value interface{}, expected string) (float64, error) {
+	amt, unit, err := ParseAmount(value)
+	if err != nil {
+		return 0, err
+	}
+	if unit != expected {
+		return 0, fmt.Errorf("expected %s, got %s", expected, unit)
+	}
+	return amt, nil
+}
+
+// naiAmount converts [satoshis, precision, nai] via exact decimal string
+// arithmetic (legacy uses decimal.Decimal; we shift the decimal point on the
+// digit string before a single float conversion to avoid double rounding).
+func naiAmount(satoshisV, precisionV, naiV interface{}) (float64, string, error) {
+	nai, ok := naiV.(string)
+	if !ok {
+		return 0, "", fmt.Errorf("invalid NAI %#v", naiV)
+	}
+	unit, ok := NAIMap[nai]
+	if !ok {
+		return 0, "", fmt.Errorf("unknown NAI %s", nai)
+	}
+	satStr, err := numberString(satoshisV)
+	if err != nil {
+		return 0, "", err
+	}
+	prec, err := numberInt(precisionV)
+	if err != nil || prec < 0 {
+		return 0, "", fmt.Errorf("invalid precision %#v", precisionV)
+	}
+	amt, err := strconv.ParseFloat(shiftDecimal(satStr, prec), 64)
+	if err != nil {
+		return 0, "", err
+	}
+	return amt, unit, nil
+}
+
+// Amount parses a steemd asset-amount string, discarding the asset type.
+func Amount(s string) (float64, error) {
+	amt, _, err := ParseAmount(s)
+	return amt, err
+}
+
+// LegacyAmount renders a value as a pre-appbase-style amount string
+// ("452574.069424 VESTS"). String input passes through unchanged.
+// Mirrors legacy_amount (normalize.py:57).
+func LegacyAmount(value interface{}) (string, error) {
+	if s, ok := value.(string); ok {
+		return s, nil
+	}
+	amt, unit, err := ParseAmount(value)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%.*f %s", assetPrecision[unit], amt, unit), nil
+}
+
+// BlockNumFromID extracts the block number from a block_id hex prefix.
+func BlockNumFromID(blockID string) (int64, error) {
+	if len(blockID) < 8 {
+		return 0, fmt.Errorf("invalid block_id %q", blockID)
+	}
+	return strconv.ParseInt(blockID[:8], 16, 64)
+}
+
+// BlockDate parses a block's timestamp field.
+func BlockDate(block map[string]interface{}) (time.Time, error) {
+	ts, _ := block["timestamp"].(string)
+	return ParseTime(ts)
+}
+
+// ParseTime converts a chain date string ("2016-03-24T16:05:00") to a
+// (zoneless) time.Time. Mirrors parse_time (normalize.py:74).
+func ParseTime(blockTime string) (time.Time, error) {
+	return time.Parse("2006-01-02T15:04:05", blockTime)
+}
+
+// UTCTimestamp converts a chain time to UTC unix seconds.
+func UTCTimestamp(date time.Time) int64 {
+	return date.UTC().Unix()
+}
+
+// LoadJSONKey parses the JSON string stored under obj[key]; empty map on
+// missing/blank/invalid. Mirrors load_json_key (normalize.py:82).
+func LoadJSONKey(obj map[string]string, key string) map[string]interface{} {
+	out := map[string]interface{}{}
+	raw, ok := obj[key]
+	if !ok || raw == "" {
+		return out
+	}
+	_ = json.Unmarshal([]byte(raw), &out)
+	return out
+}
+
+// Trunc truncates a string to maxlen with a 3-char '...' penalty when
+// exceeded. Operates on runes (Python slices by character).
+// Mirrors trunc (normalize.py:93).
+func Trunc(s string, maxlen int) string {
+	if s == "" {
+		return s
+	}
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if len(r) <= maxlen {
+		return s
+	}
+	return string(r[:maxlen-3]) + "..."
+}
+
+// SecsToStr renders seconds as e.g. "02h 30m 00s" / "01w 03d 04h 05m 06s".
+// Mirrors secs_to_str (normalize.py:101).
+func SecsToStr(secs int64) string {
+	type unit struct {
+		n    int64
+		name string
+	}
+	var out []unit
+	cycles := []struct {
+		cycle int64
+		name  string
+	}{{60, "s"}, {60, "m"}, {24, "h"}, {7, "d"}}
+	rem := secs
+	for _, c := range cycles {
+		out = append(out, unit{rem % c.cycle, c.name})
+		rem = rem / c.cycle
+		if rem == 0 {
+			break
+		}
+	}
+	if rem > 0 { // leftover = weeks
+		out = append(out, unit{rem, "w"})
+	}
+	parts := make([]string, len(out))
+	for i, u := range out {
+		parts[len(out)-1-i] = fmt.Sprintf("%02d%s", u.n, u.name)
+	}
+	return strings.Join(parts, " ")
+}
+
+// RepLog10 converts a raw steemd reputation into a UI-ready value centered
+// at 25. Uses legacy's string-based log10 (leading 4 digits + digit count)
+// so behavior matches Python bit-for-bit for the rounding it applies.
+// Mirrors rep_log10 (normalize.py:115).
+func RepLog10(rep interface{}) (float64, error) {
+	var s string
+	switch v := rep.(type) {
+	case string:
+		s = v
+	case int64:
+		s = strconv.FormatInt(v, 10)
+	case int:
+		s = strconv.Itoa(v)
+	case float64:
+		s = strconv.FormatFloat(v, 'f', -1, 64)
+	case json.Number:
+		s = v.String()
+	default:
+		return 0, fmt.Errorf("invalid reputation %#v", rep)
+	}
+	if s == "0" {
+		return 25, nil
+	}
+	sign := 1.0
+	if strings.HasPrefix(s, "-") {
+		sign = -1
+		s = s[1:]
+	}
+	// Python slices string[0:4] — for short strings this takes what exists
+	// (int("500") = 500), so take up to 4 chars rather than zero-padding.
+	if s == "" || strings.TrimLeft(s, "0") == "" {
+		return 25, nil
+	}
+	head := s
+	if len(head) > 4 {
+		head = head[:4]
+	}
+	leading, err := strconv.Atoi(head)
+	if err != nil {
+		return 0, fmt.Errorf("invalid reputation %q", s)
+	}
+	lg := math.Log10(float64(leading)) + 0.00000001
+	out := float64(len(s)-1) + (lg - math.Floor(lg))
+	out = math.Max(out-9, 0) * sign // at -9, $1 earned is approx magnitude 1
+	out = out*9 + 25                // 9 points per magnitude, centered at 25
+	return math.Round(out*100) / 100, nil
+}
+
+// SafeImgURL validates an image URL (size + http prefix) and returns it
+// trimmed; empty string when invalid. Mirrors safe_img_url (normalize.py:148).
+func SafeImgURL(url string, maxSize int) string {
+	if url != "" && len(url) < maxSize && strings.HasPrefix(url, "http") {
+		return strings.TrimSpace(url)
+	}
+	return ""
+}
+
+// StrToBool converts a booleany string to a bool; errors on anything else.
+// Mirrors strtobool (normalize.py:156).
+func StrToBool(val string) (bool, error) {
+	switch strings.ToLower(val) {
+	case "y", "yes", "t", "true", "on", "1":
+		return true, nil
+	case "n", "no", "f", "false", "off", "0":
+		return false, nil
+	default:
+		return false, fmt.Errorf("not booleany: %q", val)
+	}
+}
+
+// shiftDecimal divides an integer digit string by 10^prec exactly, returning
+// a plain decimal string ("452574069424", 6 -> "452574.069424").
+func shiftDecimal(satoshis string, prec int) string {
+	neg := strings.HasPrefix(satoshis, "-")
+	if neg {
+		satoshis = satoshis[1:]
+	}
+	satoshis = strings.TrimLeft(satoshis, "0")
+	if satoshis == "" {
+		return "0"
+	}
+	if prec == 0 {
+		if neg {
+			return "-" + satoshis
+		}
+		return satoshis
+	}
+	for len(satoshis) <= prec {
+		satoshis = "0" + satoshis
+	}
+	intPart := satoshis[:len(satoshis)-prec]
+	frac := strings.TrimRight(satoshis[len(satoshis)-prec:], "0")
+	out := intPart
+	if frac != "" {
+		out += "." + frac
+	}
+	if neg && out != "0" {
+		out = "-" + out
+	}
+	return out
+}
+
+// numberString renders a JSON-decoded number (float64/json.Number/string)
+// as an exact integer digit string.
+func numberString(v interface{}) (string, error) {
+	switch n := v.(type) {
+	case string:
+		return n, nil
+	case json.Number:
+		return n.String(), nil
+	case float64:
+		if n != math.Trunc(n) {
+			return "", fmt.Errorf("expected integer satoshis, got %v", n)
+		}
+		return strconv.FormatFloat(n, 'f', -1, 64), nil
+	case int:
+		return strconv.Itoa(n), nil
+	case int64:
+		return strconv.FormatInt(n, 10), nil
+	default:
+		return "", fmt.Errorf("invalid amount value %#v", v)
+	}
+}
+
+// numberInt renders a JSON-decoded number as int.
+func numberInt(v interface{}) (int, error) {
+	switch n := v.(type) {
+	case float64:
+		return int(n), nil
+	case json.Number:
+		i, err := strconv.Atoi(n.String())
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	case string:
+		return strconv.Atoi(n)
+	default:
+		return 0, fmt.Errorf("invalid numeric value %#v", v)
+	}
+}

--- a/internal/indexer/normalize_test.go
+++ b/internal/indexer/normalize_test.go
@@ -1,0 +1,254 @@
+package indexer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseAmount(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      interface{}
+		wantAmt float64
+		wantU   string
+		wantErr bool
+	}{
+		{"legacy string", "10.500 SBD", 10.5, "SBD", false},
+		{"NAI list SBD", []interface{}{"1050000", 3, "@@000000013"}, 1050.0, "SBD", false},
+		{"NAI list STEEM numeric", []interface{}{json.Number("1234"), 3, "@@000000021"}, 1.234, "STEEM", false},
+		{"NAI list VESTS", []interface{}{"452574069424", 6, "@@000000037"}, 452574.069424, "VESTS", false},
+		{"NAI object", map[string]interface{}{"amount": json.Number("5000"), "precision": 3, "nai": "@@000000013"}, 5.0, "SBD", false},
+		{"unknown NAI", []interface{}{"1", 3, "@@000000099"}, 0, "", true},
+		{"garbage string", "10.5SBD", 0, "", true},
+		{"garbage type", 42, 0, "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			amt, unit, err := ParseAmount(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got (%v,%v)", amt, unit)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if unit != c.wantU {
+				t.Errorf("unit = %q, want %q", unit, c.wantU)
+			}
+			diff := amt - c.wantAmt
+			if diff < -1e-9 || diff > 1e-9 {
+				t.Errorf("amount = %v, want %v", amt, c.wantAmt)
+			}
+		})
+	}
+}
+
+func TestAmountUnitHelpers(t *testing.T) {
+	if v, err := VestsAmount("1.000000 VESTS"); err != nil || v != 1 {
+		t.Errorf("VestsAmount = %v err %v", v, err)
+	}
+	if _, err := VestsAmount("1.000 SBD"); err == nil {
+		t.Error("VestsAmount should reject SBD")
+	}
+	if v, err := SBDAmount("12.250 SBD"); err != nil || v != 12.25 {
+		t.Errorf("SBDAmount = %v err %v", v, err)
+	}
+	if v, err := SteemAmount([]interface{}{"2000", 3, "@@000000021"}); err != nil || v != 2 {
+		t.Errorf("SteemAmount = %v err %v", v, err)
+	}
+	if v, err := Amount("99.999 STEEM"); err != nil || v != 99.999 {
+		t.Errorf("Amount = %v err %v", v, err)
+	}
+}
+
+func TestLegacyAmount(t *testing.T) {
+	// String passthrough.
+	if s, err := LegacyAmount("1.500 SBD"); err != nil || s != "1.500 SBD" {
+		t.Errorf("string passthrough = %q err %v", s, err)
+	}
+	// NAI → legacy with per-asset precision.
+	if s, err := LegacyAmount([]interface{}{"452574069424", 6, "@@000000037"}); err != nil || s != "452574.069424 VESTS" {
+		t.Errorf("VESTS = %q err %v", s, err)
+	}
+	if s, err := LegacyAmount([]interface{}{"2500", 3, "@@000000013"}); err != nil || s != "2.500 SBD" {
+		t.Errorf("SBD = %q err %v", s, err)
+	}
+}
+
+// TestRepLog10 pins the legacy rep_log10 formula. Expected values computed
+// with the Python implementation.
+func TestRepLog10(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want float64
+	}{
+		{"0", 25},             // literal zero
+		{int64(0), 25},        // numeric zero formats to "0"
+		{"1000000000", 25},    // 1e9  -> magnitude 0 -> centered 25
+		{"1000000000000", 52}, // 1e12 -> 3 magnitudes -> 25+27
+		{"-1000000000", 25},   // negative but max(out-9,0)=0 kills the sign
+		// 12 nines: log10(9999)≈3.99996 → 11.99996 → 51.9996 → rounds to 52.
+		{"999999999999", 52},
+	}
+	for _, c := range cases {
+		got, err := RepLog10(c.in)
+		if err != nil {
+			t.Fatalf("RepLog10(%v) error: %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("RepLog10(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+
+	// Round-trip sanity with the API-side inverse (objects.repToRaw).
+	if _, err := RepLog10("not-a-number!"); err == nil {
+		t.Error("expected error for non-numeric reputation")
+	}
+}
+
+func TestTrunc(t *testing.T) {
+	if s := Trunc("hello world", 8); s != "hello..." {
+		t.Errorf("Trunc = %q, want hello...", s)
+	}
+	if s := Trunc("short", 10); s != "short" {
+		t.Errorf("Trunc under limit = %q", s)
+	}
+	if s := Trunc("  padded  ", 10); s != "padded" {
+		t.Errorf("Trunc should trim, got %q", s)
+	}
+	// Rune-aware truncation (Python slices by character).
+	if s := Trunc("你好世界测试文本", 5); s != "你好..." {
+		t.Errorf("rune trunc = %q, want 你好...", s)
+	}
+}
+
+func TestSecsToStr(t *testing.T) {
+	cases := []struct {
+		secs int64
+		want string
+	}{
+		{0, "00s"},
+		{59, "59s"},
+		{61, "01m 01s"},
+		{9000, "02h 30m 00s"},
+		{86400, "01d 00h 00m 00s"},
+		{691200, "01w 01d 00h 00m 00s"}, // 8 days
+	}
+	for _, c := range cases {
+		if got := SecsToStr(c.secs); got != c.want {
+			t.Errorf("SecsToStr(%d) = %q, want %q", c.secs, got, c.want)
+		}
+	}
+}
+
+func TestSafeImgURL(t *testing.T) {
+	if u := SafeImgURL("https://x.com/a.png", 1024); u != "https://x.com/a.png" {
+		t.Errorf("valid url = %q", u)
+	}
+	// Legacy checks the http prefix BEFORE stripping, so leading spaces
+	// invalidate the URL; trailing spaces get trimmed.
+	if u := SafeImgURL("https://x.com/a.png  ", 1024); u != "https://x.com/a.png" {
+		t.Errorf("should trim trailing, got %q", u)
+	}
+	if u := SafeImgURL("  https://x.com/a.png", 1024); u != "" {
+		t.Errorf("leading space must invalidate (legacy checks prefix first), got %q", u)
+	}
+	if u := SafeImgURL("ftp://x.com/a.png", 1024); u != "" {
+		t.Errorf("non-http should be empty, got %q", u)
+	}
+	if u := SafeImgURL("", 1024); u != "" {
+		t.Errorf("empty should be empty")
+	}
+	// Oversized (>=1024).
+	long := "http://" + string(make([]byte, 1100))
+	if u := SafeImgURL(long, 1024); u != "" {
+		t.Errorf("oversized should be empty")
+	}
+}
+
+func TestStrToBool(t *testing.T) {
+	for _, s := range []string{"y", "YES", "true", "on", "1"} {
+		if v, err := StrToBool(s); err != nil || !v {
+			t.Errorf("StrToBool(%q) = %v err %v", s, v, err)
+		}
+	}
+	for _, s := range []string{"n", "No", "false", "off", "0"} {
+		if v, err := StrToBool(s); err != nil || v {
+			t.Errorf("StrToBool(%q) = %v err %v", s, v, err)
+		}
+	}
+	if _, err := StrToBool("maybe"); err == nil {
+		t.Error("expected error for non-booleany")
+	}
+}
+
+func TestBlockNumFromIDAndTime(t *testing.T) {
+	// "00000064" hex = 100.
+	if n, err := BlockNumFromID("0000006400aa00bb00cc00dd00ee00ff00112233"); err != nil || n != 100 {
+		t.Errorf("BlockNumFromID = %v err %v", n, err)
+	}
+	if _, err := BlockNumFromID("short"); err == nil {
+		t.Error("expected error for short id")
+	}
+
+	ts, err := ParseTime("2016-03-24T16:05:00")
+	if err != nil {
+		t.Fatalf("ParseTime: %v", err)
+	}
+	if ts.Year() != 2016 || ts.Month().String() != "March" || ts.Day() != 24 {
+		t.Errorf("ParseTime = %v", ts)
+	}
+	// Chain epoch sanity: 2016-03-24T16:05:00Z = 1458835500.
+	if UTCTimestamp(ts) != 1458835500 {
+		t.Errorf("UTCTimestamp = %d", UTCTimestamp(ts))
+	}
+
+	bd, err := BlockDate(map[string]interface{}{"timestamp": "2016-03-24T16:05:00"})
+	if err != nil || !bd.Equal(ts) {
+		t.Errorf("BlockDate = %v err %v", bd, err)
+	}
+}
+
+func TestLoadJSONKey(t *testing.T) {
+	obj := map[string]string{
+		"good":   `{"tags":["a"]}`,
+		"blank":  "",
+		"bad":    "{invalid",
+		"absent": "",
+	}
+	if m := LoadJSONKey(obj, "good"); len(m) != 1 || m["tags"] == nil {
+		t.Errorf("good = %v", m)
+	}
+	if m := LoadJSONKey(obj, "blank"); len(m) != 0 {
+		t.Errorf("blank = %v", m)
+	}
+	if m := LoadJSONKey(obj, "bad"); len(m) != 0 {
+		t.Errorf("bad should be empty map, got %v", m)
+	}
+	if m := LoadJSONKey(obj, "missing"); len(m) != 0 {
+		t.Errorf("missing = %v", m)
+	}
+}
+
+func TestShiftDecimal(t *testing.T) {
+	cases := []struct {
+		sat  string
+		prec int
+		want string
+	}{
+		{"452574069424", 6, "452574.069424"},
+		{"1050000", 3, "1050"},
+		{"5000", 3, "5"},
+		{"1", 3, "0.001"},
+		{"0", 3, "0"},
+		{"-5000", 3, "-5"},
+		{"123", 0, "123"},
+	}
+	for _, c := range cases {
+		if got := shiftDecimal(c.sat, c.prec); got != c.want {
+			t.Errorf("shiftDecimal(%q,%d) = %q, want %q", c.sat, c.prec, got, c.want)
+		}
+	}
+}

--- a/internal/steem/mutes.go
+++ b/internal/steem/mutes.go
@@ -1,0 +1,168 @@
+package steem
+
+import (
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/steemit/hivemind/pkg/logging"
+	"go.uber.org/zap"
+)
+
+// Mutes tracks the muted/irredeemable account list, loaded from a remote
+// URL and refreshed hourly on access. Port of hive/server/common/mutes.py.
+//
+// NOTE on faithfulness: the legacy blist (blacklist.usesteem.com) path is
+// dead code upstream (fetch commented out; blist always empty), so this
+// port implements the live behavior only: the irredeemables list plus the
+// reputation-derived blacklist tags.
+type Mutes struct {
+	url    string
+	client *http.Client
+
+	mu        sync.RWMutex
+	accounts  map[string]struct{}
+	listsMap  map[string][]string // per-account tag cache (legacy blist_map)
+	fetchedAt time.Time
+}
+
+// mutesRefreshInterval mirrors legacy's hourly reload check (mutes.py:69).
+const mutesRefreshInterval = time.Hour
+
+// NewMutes creates a Mutes list; when url is non-empty it loads immediately.
+func NewMutes(url string) *Mutes {
+	m := &Mutes{
+		url:      url,
+		client:   &http.Client{Timeout: 10 * time.Second},
+		accounts: map[string]struct{}{},
+		listsMap: map[string][]string{},
+	}
+	if url != "" {
+		m.Load()
+	}
+	return m
+}
+
+// Load (re)fetches the irredeemables list. On any error the list becomes
+// empty — same swallow-and-continue behavior as legacy load().
+func (m *Mutes) Load() {
+	accounts := map[string]struct{}{}
+	if m.url != "" {
+		resp, err := m.client.Get(m.url)
+		if err == nil {
+			body, rerr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if rerr == nil {
+				for _, name := range strings.Fields(string(body)) {
+					accounts[name] = struct{}{}
+				}
+			}
+		}
+	}
+
+	m.mu.Lock()
+	m.accounts = accounts
+	// New data invalidates the per-account tag cache.
+	m.listsMap = map[string][]string{}
+	m.fetchedAt = time.Now()
+	m.mu.Unlock()
+
+	logging.GetLogger().Warn("mutes list loaded",
+		zap.Int("muted", len(accounts)),
+		zap.Bool("from_url", m.url != ""))
+}
+
+// All returns a sorted snapshot of all muted accounts.
+func (m *Mutes) All() []string {
+	m.refreshIfStale()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, 0, len(m.accounts))
+	for name := range m.accounts {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Contains reports whether the account is on the irredeemables list.
+func (m *Mutes) Contains(name string) bool {
+	m.refreshIfStale()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.accounts[name]
+	return ok
+}
+
+// Lists returns the blacklist tags an account belongs to:
+// "irredeemables" when muted, plus "reputation-0"/"reputation-1" derived
+// from the (truncated) UI reputation. Results are cached per account and
+// the underlying list refreshes hourly. Mirrors Mutes.lists() (mutes.py:62).
+func (m *Mutes) Lists(name string, rep float64) []string {
+	m.refreshIfStale()
+
+	m.mu.RLock()
+	cached, ok := m.listsMap[name]
+	m.mu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	out := []string{}
+	m.mu.RLock()
+	_, muted := m.accounts[name]
+	m.mu.RUnlock()
+	if muted {
+		out = append(out, "irredeemables")
+	}
+	// Legacy uses int(rep) — truncation toward zero.
+	switch t := int(rep); {
+	case t < 1:
+		out = append(out, "reputation-0")
+	case t == 1:
+		out = append(out, "reputation-1")
+	}
+
+	m.mu.Lock()
+	m.listsMap[name] = out
+	m.mu.Unlock()
+	return out
+}
+
+func (m *Mutes) refreshIfStale() {
+	if m.url == "" {
+		return
+	}
+	m.mu.RLock()
+	stale := time.Since(m.fetchedAt) > mutesRefreshInterval
+	m.mu.RUnlock()
+	if stale {
+		m.Load()
+	}
+}
+
+// Shared instance (mirrors Mutes.set_shared_instance / Mutes.instance).
+// SharedMutes never returns nil: an unset instance behaves as an empty list.
+
+var (
+	sharedMutesMu sync.RWMutex
+	sharedMutes   = NewMutes("") // empty default
+)
+
+// SetSharedMutes installs the process-wide Mutes instance.
+func SetSharedMutes(m *Mutes) {
+	sharedMutesMu.Lock()
+	sharedMutes = m
+	sharedMutesMu.Unlock()
+}
+
+// SharedMutes returns the process-wide Mutes instance (empty behavior when
+// never configured).
+func SharedMutes() *Mutes {
+	sharedMutesMu.RLock()
+	defer sharedMutesMu.RUnlock()
+	return sharedMutes
+}

--- a/internal/steem/mutes_test.go
+++ b/internal/steem/mutes_test.go
@@ -1,0 +1,140 @@
+package steem
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMutes_LoadAndAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("badguy1 badguy2\nspamking\t threat\n"))
+	}))
+	defer srv.Close()
+
+	m := NewMutes(srv.URL)
+	all := m.All()
+	want := []string{"badguy1", "badguy2", "spamking", "threat"}
+	if len(all) != len(want) {
+		t.Fatalf("All = %v, want %v", all, want)
+	}
+	for i, name := range want {
+		if all[i] != name {
+			t.Errorf("All[%d] = %q, want %q", i, all[i], name)
+		}
+	}
+	if !m.Contains("badguy1") {
+		t.Error("Contains(badguy1) = false")
+	}
+	if m.Contains("innocent") {
+		t.Error("Contains(innocent) = true")
+	}
+}
+
+func TestMutes_UnreachableURLEmpty(t *testing.T) {
+	// Legacy swallows fetch errors into an empty list.
+	m := NewMutes("http://127.0.0.1:1/none")
+	if len(m.All()) != 0 {
+		t.Errorf("unreachable URL should yield empty list, got %v", m.All())
+	}
+}
+
+func TestMutes_EmptyURLDisabled(t *testing.T) {
+	m := NewMutes("")
+	if len(m.All()) != 0 {
+		t.Error("empty URL should be disabled")
+	}
+	// Lists still derives reputation tags without any remote data.
+	got := m.Lists("anyone", 0)
+	if len(got) != 1 || got[0] != "reputation-0" {
+		t.Errorf("Lists = %v, want [reputation-0]", got)
+	}
+}
+
+func TestMutes_Lists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("badguy badguy2"))
+	}))
+	defer srv.Close()
+
+	m := NewMutes(srv.URL)
+
+	cases := []struct {
+		name string
+		rep  float64
+		want []string
+	}{
+		{"badguy", 50, []string{"irredeemables"}},
+		// Distinct names: results are cached per name (legacy blist_map),
+		// so the same name with a different rep would return the cached one.
+		{"badguy2", 0.5, []string{"irredeemables", "reputation-0"}}, // int(0.5)=0 < 1
+		{"newbie", 1, []string{"reputation-1"}},
+		{"newbie2", 1.9, []string{"reputation-1"}}, // int(1.9)=1
+		{"regular", 42, []string{}},                // no tags
+	}
+	for _, c := range cases {
+		got := m.Lists(c.name, c.rep)
+		if len(got) != len(c.want) {
+			t.Fatalf("Lists(%q,%v) = %v, want %v", c.name, c.rep, got, c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("Lists(%q,%v)[%d] = %q, want %q", c.name, c.rep, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+func TestMutes_CacheAndRefresh(t *testing.T) {
+	body := "firstguy"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	m := NewMutes(srv.URL)
+	if !m.Contains("firstguy") {
+		t.Fatal("initial load missing firstguy")
+	}
+
+	// Cached per-account result survives a reload until cache clear.
+	cached := m.Lists("firstguy", 50)
+	if len(cached) != 1 || cached[0] != "irredeemables" {
+		t.Fatalf("Lists = %v", cached)
+	}
+
+	// Serve new content and force a reload; cache must be invalidated.
+	body = "secondguy"
+	m.Load()
+	if m.Contains("firstguy") {
+		t.Error("stale firstguy survived reload")
+	}
+	if !m.Contains("secondguy") {
+		t.Error("secondguy missing after reload")
+	}
+	if got := m.Lists("secondguy", 50); len(got) != 1 || got[0] != "irredeemables" {
+		t.Errorf("Lists(secondguy) = %v", got)
+	}
+}
+
+func TestSharedMutes(t *testing.T) {
+	// Default shared instance is non-nil and disabled.
+	if SharedMutes() == nil {
+		t.Fatal("SharedMutes should never be nil")
+	}
+	if len(SharedMutes().All()) != 0 {
+		t.Error("default shared mutes should be empty")
+	}
+
+	// Installing an instance swaps it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("sharedguy"))
+	}))
+	defer srv.Close()
+	SetSharedMutes(NewMutes(srv.URL))
+	defer SetSharedMutes(NewMutes(""))
+
+	if !SharedMutes().Contains("sharedguy") {
+		t.Error("shared instance not installed")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,11 @@ type SteemConfig struct {
 	URL        string
 	MaxBatch   int
 	MaxWorkers int
+
+	// MutedAccountsURL is the irredeemables list endpoint (whitespace-
+	// separated account names), refreshed hourly. Empty disables the list.
+	// Mirrors legacy config key muted_accounts_url.
+	MutedAccountsURL string
 }
 
 // RedisConfig holds Redis configuration
@@ -149,9 +154,10 @@ func Load() (*Config, error) {
 			StatementTimeout:     getDuration("db_statement_timeout", 30*time.Second),
 		},
 		Steem: SteemConfig{
-			URL:        getString("steemd_url", "https://api.steemit.com"),
-			MaxBatch:   getInt("max_batch", 50),
-			MaxWorkers: getInt("max_workers", 4),
+			URL:              getString("steemd_url", "https://api.steemit.com"),
+			MaxBatch:         getInt("max_batch", 50),
+			MaxWorkers:       getInt("max_workers", 4),
+			MutedAccountsURL: getString("muted_accounts_url", ""),
 		},
 		Redis: RedisConfig{
 			URL:     getString("redis_url", ""),
@@ -208,6 +214,7 @@ func setDefaults() {
 	viper.SetDefault("db_conn_max_idle_time", 10*time.Minute)
 	viper.SetDefault("db_statement_timeout", 30*time.Second)
 	viper.SetDefault("steemd_url", "https://api.steemit.com")
+	viper.SetDefault("muted_accounts_url", "")
 	viper.SetDefault("http_server_port", 8080)
 	viper.SetDefault("http_server_host", "0.0.0.0")
 	viper.SetDefault("http_read_timeout", 30*time.Second)


### PR DESCRIPTION
## Summary

First step of the CachedPost chain. Ports the two utility modules the legacy `cached_post.py` depends on (identified as missing in the plan audit): the **Mutes** moderation list singleton and the full **normalize.py** utility set.

## Mutes (`internal/steem/mutes.go`)

Port of `hive/server/common/mutes.py`:
- Irredeemables list from URL (whitespace-separated), **hourly refresh** on access, per-account tag cache (legacy `blist_map` semantics — cached by name, so same name + different rep returns the cached result, matching Python).
- `Lists(name, rep)`: `irredeemables` + `reputation-0`/`reputation-1` with Python `int()` truncation semantics (`0.5 → 0 → reputation-0`, `1.9 → 1 → reputation-1`).
- Thread-safe (RWMutex). Fetch errors degrade to empty list — same swallow-and-continue as legacy.
- Shared singleton wired into **both binaries** behind `HIVE_MUTED_ACCOUNTS_URL` (legacy key: `muted_accounts_url`), registered in `Load()` + `setDefaults()` per AGENTS.md.
- ⚠️ Faithfulness note: legacy `blacklist.usesteem.com` is **dead code upstream** (fetch commented out, `blist` always empty) — intentionally not ported.

## normalize (`internal/indexer/normalize.go`)

Port of `hive/utils/normalize.py` (16 functions + `NAI_MAP`):
- **Amount parsing** — all 3 steemd shapes: legacy string `"10.500 SBD"`, NAI array `[satoshis, precision, nai]`, NAI object. NAI conversion uses exact decimal-string shifting before a single float conversion (Python uses `decimal.Decimal`). `SBDAmount`/`SteemAmount`/`VestsAmount` unit assertions; `LegacyAmount` per-asset precision (SBD/STEEM=3, VESTS=6).
- **RepLog10** — the string-based log10 formula (leading-4-digits + digit count + 1e-8 nudge) preserved exactly, including quirks: short strings use existing digits (no zero-padding), `"0"→25`, negative sign killed by the `max(out-9, 0)` clamp.
- Time helpers, `BlockNumFromID` (hex prefix), `LoadJSONKey`, `Trunc` (rune-aware, `...` penalty), `SecsToStr`, `SafeImgURL` (prefix check BEFORE trim — matches legacy), `StrToBool`. `int_log_level` skipped (Python logging specific).

## Tests (40+ cases)

- NAI forms / unknown NAI / unit mismatch / garbage inputs
- RepLog10 boundaries cross-checked against the Python formula (3 test-expectation corrections during development were all **my test math wrong, Go right** — verified against Python)
- Mutes: load/All/Contains, unreachable URL → empty, empty URL → disabled but reputation tags still work, per-name cache, reload invalidates cache, shared instance swap (all via `httptest`)

## Validation
- `go build` / `go vet` / `go test ./...` all green.

## Test plan
- [ ] CI green

Part of the CachedPost chain (PR#6a → 6b scoring → 6c queue/dual-write → 6d notifs).