### PR TITLE
feat(indexer): port post.py scoring and normalization (PR#6b)

### DIFF
--- a/internal/indexer/scoring.go
+++ b/internal/indexer/scoring.go
@@ -1,0 +1,415 @@
+package indexer
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Port of hive/utils/post.py — post normalization and trending/hot scoring
+// used by CachedPost (PR#6c). Behavior mirrors the Python implementation,
+// including its quirks (tag slicing before the nsfw check, flag_weight's
+// cheap log10, preview truncation, [NUL] replacement).
+
+// Mention name constraints (mentions regex, post.py:18):
+//   - '@' at start, or preceded by a char NOT in [a-zA-Z0-9_!#$%&*@/]
+//   - name: 3-16 chars, first/last alnum, middle allows [.-]
+//   - NOT followed by [a-z] (Python negative lookahead; emulated below)
+var mentionRunChars = regexp.MustCompile(`^[a-zA-Z0-9.\-]+$`)
+
+// Mentions returns the @-mentioned account names in a post body
+// (lowercased, deduped, first-occurrence order). The Python version returns
+// a set (unordered); order here is deterministic.
+func Mentions(body string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := 0; i < len(body); i++ {
+		if body[i] != '@' {
+			continue
+		}
+		if i > 0 && isMentionPreceded(body[i-1]) {
+			continue
+		}
+		name, ok := scanMentionName(body, i+1)
+		if !ok {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if !seen[lower] {
+			seen[lower] = true
+			out = append(out, lower)
+		}
+	}
+	return out
+}
+
+// isMentionPreceded reports whether prev invalidates an '@' mention
+// (the class negated by the legacy regex: alnum plus _!#$%&*@/).
+func isMentionPreceded(prev byte) bool {
+	switch {
+	case prev >= 'a' && prev <= 'z',
+		prev >= 'A' && prev <= 'Z',
+		prev >= '0' && prev <= '9':
+		return true
+	}
+	return strings.IndexByte("_!#$%&*@/", prev) >= 0
+}
+
+// scanMentionName extracts the longest valid name starting at start,
+// mirroring the backtracking of the Python regex (including the
+// not-followed-by-[a-z] lookahead, which only bites when the char run
+// exceeds the 16-char name cap).
+func scanMentionName(body string, start int) (string, bool) {
+	if start >= len(body) || !isMentionAlnum(body[start]) {
+		return "", false
+	}
+	end := start
+	for end < len(body) && mentionRunChars.MatchString(string(body[end])) {
+		end++
+	}
+	run := body[start:end]
+	hi := len(run)
+	if hi > 16 {
+		hi = 16
+	}
+	for n := hi; n >= 3; n-- {
+		if !isMentionAlnum(run[n-1]) {
+			continue // last char must be alnum
+		}
+		if n < len(run) && run[n] >= 'a' && run[n] <= 'z' {
+			continue // followed by lowercase → lookahead fails
+		}
+		return run[:n], true
+	}
+	return "", false
+}
+
+func isMentionAlnum(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+}
+
+// PostBasic is the result of basic post normalization (post_basic, py:99).
+type PostBasic struct {
+	JSONMetadata     map[string]interface{}
+	Image            string
+	Tags             []string
+	IsNSFW           bool
+	Body             string
+	Preview          string
+	PayoutAt         string
+	IsPaidout        bool
+	IsPayoutDeclined bool
+	IsFullPower      bool
+}
+
+// PostBasic normalizes a steemd post's json-metadata, tags, and payout flags.
+func ComputePostBasic(post map[string]interface{}) PostBasic {
+	b := PostBasic{JSONMetadata: map[string]interface{}{}}
+
+	if raw, ok := post["json_metadata"].(string); ok && raw != "" {
+		var md map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &md); err == nil && md != nil {
+			b.JSONMetadata = md
+		}
+	}
+
+	// Thumb URL from md.image (wrapped if scalar; invalid entries dropped;
+	// key removed entirely when nothing survives — legacy mutates md).
+	if imgAny, ok := b.JSONMetadata["image"]; ok {
+		var imgs []interface{}
+		switch v := imgAny.(type) {
+		case []interface{}:
+			imgs = v
+		case string:
+			imgs = []interface{}{v}
+		}
+		var valid []interface{}
+		for _, e := range imgs {
+			s, ok := e.(string)
+			if !ok {
+				continue
+			}
+			if u := SafeImgURL(s, 1024); u != "" {
+				valid = append(valid, u)
+			}
+		}
+		if len(valid) > 0 {
+			b.JSONMetadata["image"] = valid
+			b.Image, _ = valid[0].(string)
+		} else {
+			delete(b.JSONMetadata, "image")
+		}
+	}
+
+	// Tags: category first, then md.tags (list only); normalize, dedupe,
+	// cap at 5 — nsfw check happens AFTER the cap (legacy order).
+	tags := []string{getStr(post, "category")}
+	if rawTags, ok := b.JSONMetadata["tags"].([]interface{}); ok {
+		for _, t := range rawTags {
+			tags = append(tags, pyTagString(t))
+		}
+	}
+	seen := map[string]bool{}
+	for _, t := range tags {
+		norm := truncateRunes(strings.Trim(strings.ToLower(t), "# "), 32)
+		if norm == "" || seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		b.Tags = append(b.Tags, norm)
+		if len(b.Tags) == 5 {
+			break
+		}
+	}
+	b.IsNSFW = false
+	for _, t := range b.Tags {
+		if t == "nsfw" {
+			b.IsNSFW = true
+			break
+		}
+	}
+
+	b.Body = strings.ReplaceAll(getStr(post, "body"), "\x00", "[NUL]")
+	b.Preview = truncateRunes(b.Body, 1024)
+
+	// Payout date: last_payout once paid out (cashout_time = 1969-…), else
+	// the future cashout_time.
+	cashout := getStr(post, "cashout_time")
+	b.IsPaidout = strings.HasPrefix(cashout, "1969")
+	if b.IsPaidout {
+		b.PayoutAt = getStr(post, "last_payout")
+	} else {
+		b.PayoutAt = cashout
+	}
+
+	// Payout declined: max_accepted_payout = 0, or 100% burned to null.
+	if maxPayout, err := SBDAmount(post["max_accepted_payout"]); err == nil && maxPayout == 0 {
+		b.IsPayoutDeclined = true
+	} else if bennies, ok := post["beneficiaries"].([]interface{}); ok && len(bennies) == 1 {
+		if benny, ok := bennies[0].(map[string]interface{}); ok {
+			weight, werr := numberInt(benny["weight"])
+			if getStr(benny, "account") == "null" && werr == nil && weight == 10000 {
+				b.IsPayoutDeclined = true
+			}
+		}
+	}
+
+	// 100% SP payout.
+	if psd, err := numberInt(post["percent_steem_dollars"]); err == nil && psd == 0 {
+		b.IsFullPower = true
+	}
+
+	return b
+}
+
+// legacyPostFields is the whitelist preserved in hive_posts_cache.raw_json
+// (post_legacy, py:167).
+var legacyPostFields = []string{
+	"id", "url", "root_comment", "root_author", "root_permlink",
+	"root_title", "parent_author", "parent_permlink",
+	"max_accepted_payout", "percent_steem_dollars",
+	"curator_payout_value", "allow_replies", "allow_votes",
+	"allow_curation_rewards", "beneficiaries",
+}
+
+// LegacyPostFields extracts the legacy-useful subset of a steemd post.
+func LegacyPostFields(post map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for _, k := range legacyPostFields {
+		if v, ok := post[k]; ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// PostPayout is the computed payout/vote state (post_payout, py:179).
+type PostPayout struct {
+	Payout  float64
+	RShares int64
+	CSVotes string
+	SCTrend float64
+	SCHot   float64
+}
+
+// Trending score timescales (py:198-199).
+const (
+	SCTrendTimescale = 240000.0
+	SCHotTimescale   = 10000.0
+)
+
+// PostPayout computes payout sum, rshares, the votes CSV blob, and the
+// trend/hot scores for a steemd post.
+func ComputePostPayout(post map[string]interface{}) (PostPayout, error) {
+	var p PostPayout
+
+	for _, key := range []string{"total_payout_value", "curator_payout_value", "pending_payout_value"} {
+		amt, err := SBDAmount(post[key])
+		if err != nil {
+			return p, fmt.Errorf("%s: %w", key, err)
+		}
+		p.Payout += amt
+	}
+
+	votes, _ := post["active_votes"].([]interface{})
+	rows := make([]string, 0, len(votes))
+	for _, v := range votes {
+		vote, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rsStr, err := numberString(vote["rshares"])
+		if err != nil {
+			return p, err
+		}
+		rs, err := strconv.ParseInt(rsStr, 10, 64)
+		if err != nil {
+			return p, fmt.Errorf("vote rshares %q: %w", rsStr, err)
+		}
+		p.RShares += rs
+
+		pct, err := numberString(vote["percent"])
+		if err != nil {
+			return p, err
+		}
+		rep, err := RepLog10(vote["reputation"])
+		if err != nil {
+			// Legacy rep_log10 never fails; degrade like Python's crash-free
+			// paths by treating bad reps as the default.
+			rep = 25
+		}
+		rows = append(rows, fmt.Sprintf("%s,%s,%s,%s",
+			getStr(vote, "voter"), rsStr, pct, pyFloat(rep)))
+	}
+	p.CSVotes = strings.Join(rows, "\n")
+
+	created := getStr(post, "created")
+	ts, err := ParseTime(created)
+	if err != nil {
+		return p, fmt.Errorf("created %q: %w", created, err)
+	}
+	unix := UTCTimestamp(ts)
+	p.SCTrend = Score(p.RShares, unix, SCTrendTimescale)
+	p.SCHot = Score(p.RShares, unix, SCHotTimescale)
+	return p, nil
+}
+
+// PostStats is the derived display state (post_stats, py:224).
+type PostStats struct {
+	Hide       bool
+	Gray       bool
+	AuthorRep  float64
+	FlagWeight int
+	TotalVotes int64
+	UpVotes    int64
+}
+
+// PostStats computes vote statistics and the hide/gray flags.
+func ComputePostStats(post map[string]interface{}) (PostStats, error) {
+	var s PostStats
+	var negRShares int64
+	votes, _ := post["active_votes"].([]interface{})
+	for _, v := range votes {
+		vote, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rsStr, err := numberString(vote["rshares"])
+		if err != nil {
+			return s, err
+		}
+		rs, err := strconv.ParseInt(rsStr, 10, 64)
+		if err != nil {
+			return s, fmt.Errorf("vote rshares %q: %w", rsStr, err)
+		}
+		if rs == 0 {
+			continue
+		}
+		s.TotalVotes++
+		if rs > 0 {
+			s.UpVotes++
+		} else {
+			negRShares += rs
+		}
+	}
+
+	// Cheap stake-based log10: digits of neg_rshares/2 minus 11
+	// (1 ≈ $400 of downvote stake, 2 ≈ $4,000, …). Python's str(int) of a
+	// negative value includes the sign, so count it via %d formatting.
+	s.FlagWeight = len(fmt.Sprintf("%d", negRShares/2)) - 11
+	if s.FlagWeight < 0 {
+		s.FlagWeight = 0
+	}
+
+	rep, err := RepLog10(post["author_reputation"])
+	if err != nil {
+		return s, fmt.Errorf("author_reputation: %w", err)
+	}
+	s.AuthorRep = rep
+
+	pending, _ := SBDAmount(post["pending_payout_value"])
+	hasPendingPayout := pending >= 0.02
+
+	s.Hide = rep < 0 && !hasPendingPayout
+	s.Gray = rep < 1
+	return s, nil
+}
+
+// Score calculates the trending/hot score. Source: steem tags_plugin
+// calculate_score (referenced at py:214).
+func Score(rshares int64, createdTimestamp int64, timescale float64) float64 {
+	modScore := float64(rshares) / 10000000.0
+	order := math.Log10(math.Max(math.Abs(modScore), 1))
+	sign := 1.0
+	if modScore <= 0 {
+		sign = -1
+	}
+	return sign*order + float64(createdTimestamp)/timescale
+}
+
+// --- small helpers ---
+
+func getStr(m map[string]interface{}, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+// pyTagString renders a possibly-non-string metadata tag the way Python
+// str() would.
+func pyTagString(t interface{}) string {
+	switch v := t.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case json.Number:
+		return v.String()
+	case bool:
+		return strconv.FormatBool(v)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// pyFloat formats a float like Python's str(): integral values keep ".0".
+func pyFloat(f float64) string {
+	s := strconv.FormatFloat(f, 'f', -1, 64)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return s
+}
+
+// truncateRunes caps a string at n characters (Python slices by char).
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}

--- a/internal/indexer/scoring_test.go
+++ b/internal/indexer/scoring_test.go
@@ -1,0 +1,294 @@
+package indexer
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestMentions pins the legacy regex semantics, including the negative
+// lookahead (?![a-z]) that the Go port emulates by scanning.
+func TestMentions(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"simple", "hi @alice!", []string{"alice"}},
+		{"start of string", "@bob here", []string{"bob"}},
+		{"dedupe + lowercase", "@Alice and @alice", []string{"alice"}},
+		{"too short", "x @ab y", nil},
+		{"preceded by alnum", "email x@y.com", nil},
+		{"preceded by @", "@@alice", nil},
+		{"preceded by slash", "x/@alice", nil},
+		{"underscore ends the name", "@charlie_mc", []string{"charlie"}},
+		{"trailing period trimmed from name", "cc @dave.", []string{"dave"}},
+		{"digits ok", "ping @user123 now", []string{"user123"}},
+		{"16 lowercase chars ok", "@" + strings.Repeat("a", 16), []string{strings.Repeat("a", 16)}},
+		{"17 lowercase chars: lookahead kills all", "@" + strings.Repeat("a", 17), nil},
+		{"17th char uppercase: 16-char name", "@" + strings.Repeat("a", 16) + "Zx", []string{strings.Repeat("a", 16)}},
+		{"multiple", "@one @two and @three", []string{"one", "two", "three"}},
+		{"name with dot", "see @a.b here", []string{"a.b"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Mentions(c.body)
+			if !eqStrings(got, c.want) {
+				t.Errorf("Mentions(%q) = %v, want %v", c.body, got, c.want)
+			}
+		})
+	}
+}
+
+func TestScore(t *testing.T) {
+	// Mirror of the formula; asserts the sign/order interplay.
+	ts := int64(1458835500)
+	cases := []struct {
+		rshares   int64
+		timescale float64
+	}{
+		{0, SCTrendTimescale},
+		{100000000, SCTrendTimescale}, // mod=10 → order=1
+		{-20000000, SCHotTimescale},   // mod=-2 → order=log10(2), negative sign
+	}
+	for _, c := range cases {
+		want := mirrorScore(c.rshares, ts, c.timescale)
+		got := Score(c.rshares, ts, c.timescale)
+		if math.Abs(got-want) > 1e-9 {
+			t.Errorf("Score(%d,%d,%v) = %v, want %v", c.rshares, ts, c.timescale, got, want)
+		}
+	}
+	// Concrete anchor: mod=10 → +1, ts/240000 = 6078.479…
+	anchor := Score(100000000, ts, SCTrendTimescale)
+	if math.Abs(anchor-(1+float64(ts)/240000)) > 1e-9 {
+		t.Errorf("anchor = %v", anchor)
+	}
+}
+
+func mirrorScore(rshares int64, ts int64, tscale float64) float64 {
+	mod := float64(rshares) / 1e7
+	order := math.Log10(math.Max(math.Abs(mod), 1))
+	sign := 1.0
+	if mod <= 0 {
+		sign = -1
+	}
+	return sign*order + float64(ts)/tscale
+}
+
+func steemdPost() map[string]interface{} {
+	return map[string]interface{}{
+		"author":                "alice",
+		"permlink":              "p1",
+		"category":              "life",
+		"depth":                 0,
+		"created":               "2026-01-02T03:04:05",
+		"last_update":           "2026-01-02T03:04:05",
+		"title":                 "T",
+		"body":                  "hello @bob",
+		"json_metadata":         `{"tags":["life","travel","life"],"image":["ftp://bad","https://ok.example/i.png"]}`,
+		"cashout_time":          "2026-01-09T03:04:05",
+		"last_payout":           "1969-12-31T23:59:59",
+		"max_accepted_payout":   "1000.000 SBD",
+		"percent_steem_dollars": 10000,
+		"beneficiaries":         []interface{}{},
+		"total_payout_value":    "1.000 SBD",
+		"curator_payout_value":  "0.500 SBD",
+		"pending_payout_value":  "2.500 SBD",
+		"net_rshares":           "3000",
+		"children":              2,
+		"author_reputation":     "1000000000000", // UI 52
+		"active_votes": []interface{}{
+			map[string]interface{}{"voter": "bob", "rshares": "2000", "percent": "10000", "reputation": "0"},
+			map[string]interface{}{"voter": "carol", "rshares": "-1000", "percent": "-5000", "reputation": "500000000"},
+			map[string]interface{}{"voter": "dave", "rshares": "0", "percent": "100", "reputation": "0"},
+		},
+	}
+}
+
+func TestComputePostBasic(t *testing.T) {
+	post := steemdPost()
+	b := ComputePostBasic(post)
+
+	// Tags: category + md tags, deduped, ≤5; nsfw absent.
+	if !eqStrings(b.Tags, []string{"life", "travel"}) {
+		t.Errorf("Tags = %v", b.Tags)
+	}
+	if b.IsNSFW {
+		t.Error("IsNSFW should be false")
+	}
+
+	// Image: invalid dropped, valid kept; md.image mutated to valid-only.
+	if b.Image != "https://ok.example/i.png" {
+		t.Errorf("Image = %q", b.Image)
+	}
+	imgs, _ := b.JSONMetadata["image"].([]interface{})
+	if len(imgs) != 1 || imgs[0] != "https://ok.example/i.png" {
+		t.Errorf("md.image = %v", imgs)
+	}
+
+	// Not paid out (cashout 2026): payout_at = cashout_time.
+	if b.IsPaidout || b.PayoutAt != "2026-01-09T03:04:05" {
+		t.Errorf("PayoutAt = %q paid=%v", b.PayoutAt, b.IsPaidout)
+	}
+	if b.IsPayoutDeclined || b.IsFullPower {
+		t.Error("declined/full_power should be false")
+	}
+	if b.Preview != "hello @bob" {
+		t.Errorf("Preview = %q", b.Preview)
+	}
+}
+
+func TestComputePostBasic_PaidAndDeclined(t *testing.T) {
+	post := steemdPost()
+	// Paid out: cashout_time resets to 1969 epoch.
+	post["cashout_time"] = "1969-12-31T23:59:59"
+	b := ComputePostBasic(post)
+	if !b.IsPaidout || b.PayoutAt != "1969-12-31T23:59:59" {
+		t.Errorf("paid: %v %q", b.IsPaidout, b.PayoutAt)
+	}
+
+	// Declined via max_accepted_payout = 0.
+	post["max_accepted_payout"] = "0.000 SBD"
+	if b = ComputePostBasic(post); !b.IsPayoutDeclined {
+		t.Error("max=0 should decline")
+	}
+
+	// Declined via 100% burn beneficiary.
+	post["max_accepted_payout"] = "1000.000 SBD"
+	post["beneficiaries"] = []interface{}{
+		map[string]interface{}{"account": "null", "weight": 10000},
+	}
+	if b = ComputePostBasic(post); !b.IsPayoutDeclined {
+		t.Error("null beneficiary 100% should decline")
+	}
+	// 50% burn does not decline.
+	post["beneficiaries"] = []interface{}{
+		map[string]interface{}{"account": "null", "weight": 5000},
+	}
+	if b = ComputePostBasic(post); b.IsPayoutDeclined {
+		t.Error("50% beneficiary should not decline")
+	}
+
+	// Full power.
+	post["percent_steem_dollars"] = 0
+	if b = ComputePostBasic(post); !b.IsFullPower {
+		t.Error("percent 0 should be full power")
+	}
+}
+
+func TestComputePostPayout(t *testing.T) {
+	post := steemdPost()
+	p, err := ComputePostPayout(post)
+	if err != nil {
+		t.Fatalf("ComputePostPayout: %v", err)
+	}
+	if p.Payout != 4.0 { // 1.0 + 0.5 + 2.5
+		t.Errorf("Payout = %v, want 4", p.Payout)
+	}
+	if p.RShares != 1000 { // 2000 - 1000 + 0
+		t.Errorf("RShares = %d", p.RShares)
+	}
+	lines := strings.Split(p.CSVotes, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("CSVotes lines = %d: %q", len(lines), p.CSVotes)
+	}
+	// rep 0 → 25 → Python str() keeps ".0".
+	if lines[0] != "bob,2000,10000,25.0" {
+		t.Errorf("line0 = %q", lines[0])
+	}
+	if lines[1] != "carol,-1000,-5000,25.0" {
+		t.Errorf("line1 = %q", lines[1])
+	}
+	// Scores: rshares=1000 → mod=1e-4 → order=0 → ±0; anchor trend.
+	want := mirrorScore(1000, 1767323045, SCTrendTimescale) // 2026-01-02T03:04:05Z
+	if math.Abs(p.SCTrend-want) > 1e-9 {
+		t.Errorf("SCTrend = %v, want %v", p.SCTrend, want)
+	}
+}
+
+func TestComputePostStats(t *testing.T) {
+	post := steemdPost()
+	s, err := ComputePostStats(post)
+	if err != nil {
+		t.Fatalf("ComputePostStats: %v", err)
+	}
+	if s.TotalVotes != 2 || s.UpVotes != 1 { // zero-rshares vote skipped
+		t.Errorf("votes = %d/%d", s.TotalVotes, s.UpVotes)
+	}
+	// neg_rshares=-1000 → /2 = -500 → "-500" len 4 → 4-11 <0 → 0.
+	if s.FlagWeight != 0 {
+		t.Errorf("FlagWeight = %d", s.FlagWeight)
+	}
+	if s.AuthorRep != 52 {
+		t.Errorf("AuthorRep = %v", s.AuthorRep)
+	}
+	// rep 52 → not gray, not hidden; pending 2.5 ≥ 0.02 anyway.
+	if s.Gray || s.Hide {
+		t.Errorf("gray=%v hide=%v", s.Gray, s.Hide)
+	}
+}
+
+func TestComputePostStats_HideGray(t *testing.T) {
+	post := steemdPost()
+	// UI rep < 1 (negative raw rep) → gray; pending ≥ 0.02 keeps it visible.
+	post["author_reputation"] = "-10000000000000000" // UI ≈ -29
+	s, _ := ComputePostStats(post)
+	if !s.Gray || s.Hide {
+		t.Errorf("gray=%v hide=%v, want gray only (pending payout)", s.Gray, s.Hide)
+	}
+	// No pending payout → hidden.
+	post["pending_payout_value"] = "0.000 SBD"
+	s, _ = ComputePostStats(post)
+	if !s.Hide {
+		t.Error("negative rep + no pending should hide")
+	}
+	// Flag weight: neg_rshares = -2e13 → /2 = -1e13 → 15 digits → 4.
+	post["active_votes"] = []interface{}{
+		map[string]interface{}{"voter": "x", "rshares": "-20000000000000", "percent": "-100", "reputation": "0"},
+	}
+	s, _ = ComputePostStats(post)
+	if s.FlagWeight != 4 {
+		t.Errorf("FlagWeight = %d, want 4", s.FlagWeight)
+	}
+}
+
+func TestLegacyPostFields(t *testing.T) {
+	post := steemdPost()
+	post["url"] = "/life/@alice/p1"
+	post["root_title"] = "T"
+	post["should_drop"] = "x"
+	out := LegacyPostFields(post)
+	if _, ok := out["url"]; !ok {
+		t.Error("url missing")
+	}
+	if _, ok := out["root_title"]; !ok {
+		t.Error("root_title missing")
+	}
+	if _, ok := out["should_drop"]; ok {
+		t.Error("non-whitelisted key leaked")
+	}
+	if _, ok := out["author"]; ok {
+		t.Error("author should not be in legacy set")
+	}
+}
+
+func TestPyFloat(t *testing.T) {
+	if pyFloat(25) != "25.0" {
+		t.Errorf("pyFloat(25) = %q", pyFloat(25))
+	}
+	if pyFloat(-7.25) != "-7.25" {
+		t.Errorf("pyFloat(-7.25) = %q", pyFloat(-7.25))
+	}
+}


### PR DESCRIPTION
## Summary

Second step of the CachedPost chain. Ports the computation layer of `hive/utils/post.py` (on top of PR#6a's Mutes + normalize).

## What's ported (`internal/indexer/scoring.go`)

### Mentions
@-mention extraction. The legacy regex relies on a negative lookahead `(?![a-z])` that Go's RE2 cannot express — replaced with an **equivalent hand-rolled scanner** preserving the backtracking semantics:
- longest valid name (3–16 chars, alnum endpoints, middle allows `.-`)
- the lookahead only matters when the char run exceeds 16: **17 lowercase chars yield NO mention; 16 + uppercase does** (both covered by tests)

### ComputePostBasic
json-metadata + tags + payout flags, faithful to quirks:
- invalid images dropped; `md.image` key **removed** when nothing survives (legacy mutates the json that gets stored)
- tag pipeline: category + md.tags → strip '# '/lower/32-cap/dedupe/**first 5** — nsfw checked **after** the cap (legacy order)
- `[NUL]` body replacement, 1024-char preview
- paid-out = `cashout_time` starts with `1969`; payout_at = last_payout when paid
- declined payout: `max_accepted_payout == 0` **or** single `null` beneficiary at 10000 weight (50% does not decline)
- full power: `percent_steem_dollars == 0`

### ComputePostPayout
payout = total + curator + pending (SBD); rshares sum; **votes CSV blob** (`voter,rshares,percent,rep` — rep formatted like Python `str()`, integral values keep `.0`); `sc_trend` (timescale 240000) / `sc_hot` (10000) via `Score` (steem `calculate_score`).

### ComputePostStats
vote tallies (zero-rshares skipped), stake-based **flag_weight** (digit count of `neg_rshares/2` minus 11 — sign counted like Python `str(int(...))`), `author_rep` via RepLog10, `hide = rep<0 && pending < 0.02`, `gray = rep<1`.

### LegacyPostFields
the `raw_json` whitelist (id/url/root_*/parent_*/payout settings/allow_*/beneficiaries).

## Tests
15 mention cases (lookahead edges), score anchors vs mirror formula, full matrices for paid-out/declined/hide-gray/flag-weight, `pyFloat` formatting. One test-expectation fix during development was my epoch math (2016 vs 2026) — implementation was right.

## Validation
`go build` / `go vet` / `go test ./...` all green.

Part of the CachedPost chain (6a merged → **6b** → 6c queue/dual-write → 6d notifs).
