### PR TITLE
feat(indexer): implement reply/mention/vote notifications (PR#6d)

### DIFF
--- a/internal/indexer/block_processor.go
+++ b/internal/indexer/block_processor.go
@@ -39,8 +39,8 @@ func NewBlockProcessor(database *db.DB, repo *db.Repository, steemProvider steem
 	logger := logging.GetLogger().With(zap.String("component", "block-processor"))
 
 	cachedPost := NewCachedPost(database.DB, steemProvider)
-	// Notifications (reply/mention/vote) are wired in PR#6d; the hook stays
-	// nil until then.
+	// Reply/mention/vote notifications ride along the cache flush.
+	NewPostNotifs(database.DB, cachedPost, NewNotifyIndexer(repo)).Install()
 
 	return &BlockProcessor{
 		db:               database,

--- a/internal/indexer/cached_post.go
+++ b/internal/indexer/cached_post.go
@@ -170,6 +170,15 @@ func (c *CachedPost) Undelete(ctx context.Context, postID int64, author, permlin
 	return nil
 }
 
+// PopPendingVoters removes and returns the voters queued for a vote notif.
+func (c *CachedPost) PopPendingVoters(url string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	voters := c.votes[url]
+	delete(c.votes, url)
+	return voters
+}
+
 // dirty marks a post at the given level; priority only ever upgrades.
 func (c *CachedPost) dirty(level int, author, permlink string, pid int64) {
 	url := author + "/" + permlink

--- a/internal/indexer/notifs.go
+++ b/internal/indexer/notifs.go
@@ -1,0 +1,424 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/steemit/hivemind/internal/models"
+	"github.com/steemit/hivemind/internal/steem"
+	"github.com/steemit/hivemind/pkg/logging"
+)
+
+// PostNotifs implements the reply/mention/vote notifications emitted while
+// CachedPost flushes (legacy cached_post.py::_notfs). It is installed as the
+// CachedPost notifs hook (PR#6c left it nil).
+//
+// The per-item existence/mute checks the legacy performs one-by-one
+// (_mentioned/_voted/_muted) are batched into single IN queries per post.
+type PostNotifs struct {
+	db     *gorm.DB
+	cp     *CachedPost
+	notify *NotifyIndexer
+	logger *zap.Logger
+
+	ranksMu   sync.RWMutex
+	ranks     map[int64]int // account_id -> 1-based vote_weight rank
+	ranksLoad bool
+}
+
+// NewPostNotifs creates the notifier; call Hook to install it on a CachedPost.
+func NewPostNotifs(database *gorm.DB, cp *CachedPost, notify *NotifyIndexer) *PostNotifs {
+	return &PostNotifs{
+		db:     database,
+		cp:     cp,
+		notify: notify,
+		logger: logging.GetLogger().With(zap.String("component", "post-notifs")),
+	}
+}
+
+// Install wires this notifier into the CachedPost flush pipeline.
+func (p *PostNotifs) Install() {
+	p.cp.SetNotifsHook(p.Hook)
+}
+
+// Hook is the notifs entry point invoked once per processed post.
+func (p *PostNotifs) Hook(ctx context.Context, post map[string]interface{}, pid int64, level string, payout float64) {
+	author := getStr(post, "author")
+	parentAuthor := getStr(post, "parent_author")
+	when, err := ParseTime(getStr(post, "last_update"))
+	if err != nil {
+		if when, err = ParseTime(getStr(post, "created")); err != nil {
+			when = time.Now().UTC()
+		}
+	}
+
+	ids, err := p.accountIDs(ctx, author, parentAuthor)
+	if err != nil {
+		p.logger.Warn("notifs: account lookup failed", zap.Error(err))
+		return
+	}
+	authorID, hasAuthor := ids[author]
+	if !hasAuthor {
+		return
+	}
+
+	if level == "insert" {
+		p.replyNotifs(ctx, post, pid, author, parentAuthor, authorID, ids, when)
+	}
+	if level == "insert" || level == "update" {
+		p.mentionNotifs(ctx, post, pid, author, parentAuthor, authorID, when)
+	}
+	p.voteNotifs(ctx, post, pid, author, authorID, payout)
+}
+
+// replyNotif notifies the parent author of a new comment/reply.
+func (p *PostNotifs) replyNotifs(ctx context.Context, post map[string]interface{}, pid int64,
+	author, parentAuthor string, authorID int64, ids map[string]int64, when time.Time) {
+	if parentAuthor == "" || parentAuthor == author {
+		return
+	}
+	if steem.SharedMutes().Contains(parentAuthor) {
+		return // irredeemable parent author
+	}
+	parentID, ok := ids[parentAuthor]
+	if !ok {
+		return
+	}
+	muted, err := p.isMuted(ctx, parentID, authorID)
+	if err != nil || muted {
+		return
+	}
+
+	typeID := models.NotifyTypeReplyComment
+	if depth, _ := numberInt(post["depth"]); depth == 1 {
+		typeID = models.NotifyTypeReply
+	}
+	score := p.defaultScore(ctx, authorID)
+	if err := p.notify.Write(ctx, typeID, when, &authorID, &parentID, nil, &pid, nil, &score); err != nil {
+		p.logger.Warn("reply notif write failed", zap.Error(err))
+	}
+}
+
+// mentionNotifs notifies @mentioned accounts (spam-capped by author score).
+func (p *PostNotifs) mentionNotifs(ctx context.Context, post map[string]interface{}, pid int64,
+	author, parentAuthor string, authorID int64, when time.Time) {
+	names := Mentions(getStr(post, "body"))
+	if len(names) == 0 {
+		return
+	}
+	resolved, err := p.accountIDs(ctx, names...) // existence filter
+	if err != nil {
+		p.logger.Warn("notifs: mention lookup failed", zap.Error(err))
+		return
+	}
+	delete(resolved, author)
+	delete(resolved, parentAuthor)
+	if len(resolved) == 0 {
+		return
+	}
+
+	score := p.defaultScore(ctx, authorID)
+	maxMentions := 25
+	if score < 30 {
+		maxMentions = 5
+	} else if score < 60 {
+		maxMentions = 10
+	}
+	if len(resolved) > maxMentions {
+		p.logger.Info("skipping mentions (over cap)",
+			zap.Int("mentions", len(resolved)),
+			zap.Int("cap", maxMentions),
+			zap.String("url", "@"+author+"/"+getStr(post, "permlink")))
+		return
+	}
+
+	// Sort mention names for deterministic ordering.
+	mentionNames := make([]string, 0, len(resolved))
+	for name := range resolved {
+		mentionNames = append(mentionNames, name)
+	}
+	sort.Strings(mentionNames)
+
+	penalty := 2 * (len(mentionNames) - 1)
+	if penalty > int(score) {
+		penalty = int(score)
+	}
+
+	// Batch: already-mentioned (type 16) and muted (follows state 2/3).
+	mentionIDs := make([]int64, 0, len(mentionNames))
+	for _, name := range mentionNames {
+		mentionIDs = append(mentionIDs, resolved[name])
+	}
+	already, err := p.existingMentions(ctx, pid, mentionIDs)
+	if err != nil {
+		p.logger.Warn("notifs: mention dedup query failed", zap.Error(err))
+		return
+	}
+	mutedSet, err := p.mutedTargets(ctx, authorID, mentionIDs)
+	if err != nil {
+		p.logger.Warn("notifs: mention mute query failed", zap.Error(err))
+		return
+	}
+
+	finalScore := int16(int(score) - penalty)
+	for _, name := range mentionNames {
+		mid := resolved[name]
+		if already[mid] || mutedSet[mid] {
+			continue
+		}
+		if err := p.notify.Write(ctx, models.NotifyTypeMention, when, &authorID, &mid, nil, &pid, nil, &finalScore); err != nil {
+			p.logger.Warn("mention notif write failed", zap.Error(err))
+		}
+	}
+}
+
+// voteNotifs notifies the author of significant votes queued via Vote().
+func (p *PostNotifs) voteNotifs(ctx context.Context, post map[string]interface{}, pid int64,
+	author string, authorID int64, payout float64) {
+	url := author + "/" + getStr(post, "permlink")
+	voters := p.cp.PopPendingVoters(url)
+	if len(voters) == 0 {
+		return
+	}
+	voterSet := map[string]bool{}
+	for _, v := range voters {
+		voterSet[v] = true
+	}
+
+	netStr, _ := numberString(post["net_rshares"])
+	net, _ := strconv.ParseFloat(netStr, 64)
+	ratio := 0.0
+	if net != 0 {
+		ratio = payout / net
+	}
+
+	// Resolve voter ids once (only queued voters that actually voted).
+	votes, _ := post["active_votes"].([]interface{})
+	var voterNames []string
+	for _, v := range votes {
+		vote, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if voterSet[getStr(vote, "voter")] {
+			voterNames = append(voterNames, getStr(vote, "voter"))
+		}
+	}
+	if len(voterNames) == 0 {
+		return
+	}
+	voterIDs, err := p.accountIDs(ctx, voterNames...)
+	if err != nil {
+		p.logger.Warn("notifs: voter lookup failed", zap.Error(err))
+		return
+	}
+	voterIDList := make([]int64, 0, len(voterIDs))
+	for _, id := range voterIDs {
+		voterIDList = append(voterIDList, id)
+	}
+	votedAlready, err := p.existingVotes(ctx, authorID, pid, voterIDList)
+	if err != nil {
+		p.logger.Warn("notifs: vote dedup query failed", zap.Error(err))
+		return
+	}
+
+	for _, v := range votes {
+		vote, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		voter := getStr(vote, "voter")
+		if !voterSet[voter] {
+			continue
+		}
+		rsStr, _ := numberString(vote["rshares"])
+		rs, err := strconv.ParseInt(rsStr, 10, 64)
+		if err != nil || rs < 10000000000 { // legacy: rshares < 10e9 skipped
+			continue
+		}
+		voterID, ok := voterIDs[voter]
+		if !ok {
+			continue
+		}
+		contrib := int64(1000 * ratio * float64(rs))
+		if contrib < 20 { // < $0.020
+			continue
+		}
+		if votedAlready[voterID] {
+			continue
+		}
+
+		// $1 of contribution ≈ score 75 (digits-1)*25, capped at 100.
+		score := int16(len(fmt.Sprintf("%d", contrib))-1) * 25
+		if score > 100 {
+			score = 100
+		}
+		payload := fmt.Sprintf("$%.3f", float64(contrib)/1000)
+		when, err := ParseTime(getStr(vote, "time"))
+		if err != nil {
+			when, _ = ParseTime(getStr(post, "created"))
+		}
+		if err := p.notify.Write(ctx, models.NotifyTypeVote, when, &voterID, &authorID, nil, &pid, &payload, &score); err != nil {
+			p.logger.Warn("vote notif write failed", zap.Error(err))
+		}
+	}
+}
+
+// --- helpers ---
+
+// accountIDs batch-resolves names to ids (missing names simply absent).
+func (p *PostNotifs) accountIDs(ctx context.Context, names ...string) (map[string]int64, error) {
+	out := map[string]int64{}
+	if len(names) == 0 {
+		return out, nil
+	}
+	type row struct {
+		ID   int64
+		Name string
+	}
+	var rows []row
+	err := p.db.WithContext(ctx).
+		Table("hive_accounts").
+		Select("id", "name").
+		Where("name IN ?", names).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.Name] = r.ID
+	}
+	return out, nil
+}
+
+// isMuted reports whether follower ignores target (state IN (2,3)).
+func (p *PostNotifs) isMuted(ctx context.Context, follower, target int64) (bool, error) {
+	var n int64
+	err := p.db.WithContext(ctx).
+		Table("hive_follows").
+		Select("COUNT(*)").
+		Where("follower = ? AND following = ? AND state IN (2, 3)", follower, target).
+		Scan(&n).Error
+	return n > 0, err
+}
+
+// mutedTargets batch variant of isMuted: which targets the follower ignores.
+func (p *PostNotifs) mutedTargets(ctx context.Context, follower int64, targets []int64) (map[int64]bool, error) {
+	out := map[int64]bool{}
+	if len(targets) == 0 {
+		return out, nil
+	}
+	var ids []int64
+	err := p.db.WithContext(ctx).
+		Table("hive_follows").
+		Select("following").
+		Where("follower = ? AND following IN ? AND state IN (2, 3)", follower, targets).
+		Scan(&ids).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out, nil
+}
+
+// existingMentions returns dst accounts already mentioned on this post.
+func (p *PostNotifs) existingMentions(ctx context.Context, postID int64, dstIDs []int64) (map[int64]bool, error) {
+	out := map[int64]bool{}
+	if len(dstIDs) == 0 {
+		return out, nil
+	}
+	var ids []int64
+	err := p.db.WithContext(ctx).
+		Table("hive_notifs").
+		Select("dst_id").
+		Where("post_id = ? AND type_id = ? AND dst_id IN ?", postID, models.NotifyTypeMention, dstIDs).
+		Scan(&ids).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out, nil
+}
+
+// existingVotes returns src accounts that already have a vote notif.
+func (p *PostNotifs) existingVotes(ctx context.Context, dstID, postID int64, srcIDs []int64) (map[int64]bool, error) {
+	out := map[int64]bool{}
+	if len(srcIDs) == 0 {
+		return out, nil
+	}
+	var ids []int64
+	err := p.db.WithContext(ctx).
+		Table("hive_notifs").
+		Select("src_id").
+		Where("dst_id = ? AND post_id = ? AND type_id = ? AND src_id IN ?",
+			dstID, postID, models.NotifyTypeVote, srcIDs).
+		Scan(&ids).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out, nil
+}
+
+// defaultScore maps an account's vote_weight rank to a notification score
+// (legacy Accounts.default_score / fetch_ranks; rank is 1-based).
+func (p *PostNotifs) defaultScore(ctx context.Context, accountID int64) int16 {
+	p.ranksMu.RLock()
+	loaded := p.ranksLoad
+	p.ranksMu.RUnlock()
+	if !loaded {
+		p.fetchRanks(ctx)
+	}
+	p.ranksMu.RLock()
+	rank, ok := p.ranks[accountID]
+	p.ranksMu.RUnlock()
+	if !ok {
+		rank = 1000000
+	}
+	switch {
+	case rank < 200:
+		return 70 // top 0.02%
+	case rank < 1000:
+		return 60 // top 0.1%
+	case rank < 6500:
+		return 50 // top 0.5%
+	case rank < 25000:
+		return 40 // top 2%
+	case rank < 100000:
+		return 30 // top 8%
+	default:
+		return 20
+	}
+}
+
+func (p *PostNotifs) fetchRanks(ctx context.Context) {
+	var ids []int64
+	if err := p.db.WithContext(ctx).
+		Table("hive_accounts").
+		Select("id").
+		Order("vote_weight DESC").
+		Scan(&ids).Error; err != nil {
+		p.logger.Warn("fetch_ranks failed; defaulting all scores", zap.Error(err))
+	}
+	ranks := make(map[int64]int, len(ids))
+	for i, id := range ids {
+		ranks[id] = i + 1 // 1-based, like legacy enumerate(rank+1)
+	}
+	p.ranksMu.Lock()
+	p.ranks = ranks
+	p.ranksLoad = true
+	p.ranksMu.Unlock()
+}

--- a/internal/indexer/notifs_test.go
+++ b/internal/indexer/notifs_test.go
@@ -1,0 +1,210 @@
+package indexer
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
+)
+
+// notifsPost builds a steemd comment post (depth 1) mentioning @bob.
+func notifsComment() map[string]interface{} {
+	p := steemdPostFor("alice", "c1", "hello @bob check this")
+	p["depth"] = 1
+	p["parent_author"] = "rooter"
+	p["parent_permlink"] = "root-post"
+	return p
+}
+
+func TestPostNotifs_ReplyMention(t *testing.T) {
+	database, repo, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Accounts: alice (author), rooter (parent), bob (mentioned).
+	tx := database.DB.WithContext(ctx).Begin()
+	for _, name := range []string{"alice", "rooter", "bob"} {
+		tx.Create(&models.Account{Name: name, CreatedAt: time.Unix(1458845200, 0), VoteWeight: 1000})
+	}
+	tx.Commit()
+
+	// Parent post in hive_posts (rooter/root-post).
+	root := &models.Post{Author: "rooter", Permlink: "root-post", Category: "life",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Depth: 0, IsValid: true}
+	database.DB.WithContext(ctx).Create(root)
+	comment := &models.Post{Author: "alice", Permlink: "c1", Category: "life",
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), Depth: 1,
+		ParentID: sql.NullInt64{Int64: root.ID, Valid: true}, IsValid: true}
+	database.DB.WithContext(ctx).Create(comment)
+
+	accountRepo := db.NewAccountRepository(repo)
+	alice, _ := accountRepo.GetByName(ctx, "alice")
+	rooter, _ := accountRepo.GetByName(ctx, "rooter")
+	bob, _ := accountRepo.GetByName(ctx, "bob")
+
+	provider := &fakeSteemProvider{}
+	cp := NewCachedPost(database.DB, provider)
+	pn := NewPostNotifs(database.DB, cp, NewNotifyIndexer(repo))
+	pn.Install()
+
+	post := notifsComment()
+	pn.Hook(ctx, post, comment.ID, "insert", 3.0)
+
+	// Two notifs expected: reply → rooter, mention → bob.
+	type notifRow struct {
+		TypeID int16
+		SrcID  int64
+		DstID  int64
+		PostID int64
+		Score  int16
+	}
+	var notifs []notifRow
+	database.DB.WithContext(ctx).
+		Table("hive_notifs").
+		Select("type_id", "src_id", "dst_id", "post_id", "score").
+		Order("type_id").
+		Scan(&notifs)
+
+	if len(notifs) != 2 {
+		t.Fatalf("expected 2 notifs, got %+v", notifs)
+	}
+	// type 12 = reply (depth 1)
+	if notifs[0].TypeID != models.NotifyTypeReply || notifs[0].DstID != rooter.ID || notifs[0].SrcID != alice.ID {
+		t.Errorf("reply notif = %+v", notifs[0])
+	}
+	// type 16 = mention
+	if notifs[1].TypeID != models.NotifyTypeMention || notifs[1].DstID != bob.ID {
+		t.Errorf("mention notif = %+v", notifs[1])
+	}
+
+	// Dedup: running the hook again must not duplicate the mention.
+	pn.Hook(ctx, post, comment.ID, "update", 3.0)
+	var n int64
+	database.DB.WithContext(ctx).Table("hive_notifs").
+		Where("type_id = ?", models.NotifyTypeMention).Count(&n)
+	if n != 1 {
+		t.Errorf("mention notif duplicated: %d", n)
+	}
+}
+
+func TestPostNotifs_Vote(t *testing.T) {
+	database, repo, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx := database.DB.WithContext(ctx).Begin()
+	tx.Create(&models.Account{Name: "alice", CreatedAt: time.Unix(1458845200, 0)})
+	tx.Create(&models.Account{Name: "whale", CreatedAt: time.Unix(1458845200, 0)})
+	tx.Commit()
+	post := &models.Post{Author: "alice", Permlink: "p1", Category: "life",
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), Depth: 0, IsValid: true}
+	database.DB.WithContext(ctx).Create(post)
+
+	accountRepo := db.NewAccountRepository(repo)
+	alice, _ := accountRepo.GetByName(ctx, "alice")
+	whale, _ := accountRepo.GetByName(ctx, "whale")
+
+	provider := &fakeSteemProvider{}
+	cp := NewCachedPost(database.DB, provider)
+	pn := NewPostNotifs(database.DB, cp, NewNotifyIndexer(repo))
+	pn.Install()
+
+	// Queue a vote from whale, then flush a post with a big vote.
+	cp.Vote("alice", "p1", post.ID, "whale")
+
+	steemd := steemdPostFor("alice", "p1", "body")
+	steemd["net_rshares"] = "100000000000" // 1e11
+	steemd["active_votes"] = []interface{}{
+		map[string]interface{}{
+			"voter": "whale", "rshares": "100000000000", // 1e11 ≥ 10e9
+			"percent": "10000", "reputation": "0",
+			"time": "2026-01-02T04:00:00",
+		},
+	}
+	// payout 3.0, net 1e11 → ratio 3e-11 (inexact in binary); legacy Python
+	// computes int(1000 * 3e-11 * 1e11) = 2999 (verified against Python),
+	// so contrib truncates to 2999 → $2.999, score (4-1)*25 = 75.
+	pn.Hook(ctx, steemd, post.ID, "upvote", 3.0)
+
+	type notifRow struct {
+		TypeID  int16
+		SrcID   int64
+		DstID   int64
+		Payload string
+		Score   int16
+	}
+	var notifs []notifRow
+	database.DB.WithContext(ctx).
+		Table("hive_notifs").
+		Select("type_id", "src_id", "dst_id", "payload", "score").
+		Where("type_id = ?", models.NotifyTypeVote).
+		Scan(&notifs)
+
+	if len(notifs) != 1 {
+		t.Fatalf("expected 1 vote notif, got %+v", notifs)
+	}
+	n := notifs[0]
+	if n.SrcID != whale.ID || n.DstID != alice.ID {
+		t.Errorf("vote notif ids = %+v", n)
+	}
+	if n.Payload != "$2.999" {
+		t.Errorf("payload = %q, want $2.999 (matches legacy float math)", n.Payload)
+	}
+	// contrib=2999 → 4 digits → (4-1)*25 = 75.
+	if n.Score != 75 {
+		t.Errorf("score = %d, want 75", n.Score)
+	}
+
+	// Small votes (< 10e9 rshares) produce no notifs even when queued.
+	cp.Vote("alice", "p1", post.ID, "minnow")
+	steemd["active_votes"] = []interface{}{
+		map[string]interface{}{
+			"voter": "minnow", "rshares": "1000000", // tiny
+			"percent": "100", "reputation": "0", "time": "2026-01-02T04:00:00",
+		},
+	}
+	pn.Hook(ctx, steemd, post.ID, "upvote", 3.0)
+
+	var count int64
+	database.DB.WithContext(ctx).Table("hive_notifs").
+		Where("type_id = ?", models.NotifyTypeVote).Count(&count)
+	if count != 1 {
+		t.Errorf("small vote should not notify, count = %d", count)
+	}
+}
+
+func TestPostNotifs_MentionSpamCap(t *testing.T) {
+	database, repo, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Six mentioned accounts; author default score 20 (no vote_weight) →
+	// cap 5 → ALL mentions skipped.
+	tx := database.DB.WithContext(ctx).Begin()
+	tx.Create(&models.Account{Name: "alice", CreatedAt: time.Unix(1458845200, 0)})
+	for _, n := range []string{"u1", "u2", "u3", "u4", "u5", "u6"} {
+		tx.Create(&models.Account{Name: n, CreatedAt: time.Unix(1458845200, 0)})
+	}
+	tx.Commit()
+	post := &models.Post{Author: "alice", Permlink: "p1", Category: "life",
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), Depth: 0, IsValid: true}
+	database.DB.WithContext(ctx).Create(post)
+
+	provider := &fakeSteemProvider{}
+	cp := NewCachedPost(database.DB, provider)
+	pn := NewPostNotifs(database.DB, cp, NewNotifyIndexer(repo))
+	pn.Install()
+
+	steemd := steemdPostFor("alice", "p1", "hi @u1 @u2 @u3 @u4 @u5 @u6")
+	pn.Hook(ctx, steemd, post.ID, "insert", 0)
+
+	var n int64
+	database.DB.WithContext(ctx).Table("hive_notifs").
+		Where("type_id = ?", models.NotifyTypeMention).Count(&n)
+	if n != 0 {
+		t.Errorf("6 mentions over cap 5 should all be skipped, got %d", n)
+	}
+}


### PR DESCRIPTION
## Summary

**Final step of the CachedPost chain** (6a ✅ → 6b ✅ → 6c ✅ → **6d**). Installs the PR#6c nil-guarded notifs hook with a faithful port of legacy `cached_post.py::_notfs` — including the batching optimization the plan called for (the legacy issues per-item dedup/mute queries; here they're single IN queries per post).

## The three branches

### Reply (insert level)
Parent author notified unless **irredeemable** (Mutes, from PR#6a) or **ignoring** the author (`hive_follows` state 2/3). Type `reply` at depth 1, `reply_comment` deeper. Score from the author's vote-weight rank.

### Mentions (insert/update)
@names via `Mentions` (PR#6b), filtered to existing accounts minus author/parent. **Spam-capped by author score** (<30 → 5, <60 → 10, else 25 — over cap skips ALL with a log). Linear penalty `min(score, 2*(n-1))`. Already-mentioned (type 16) and muted recipients deduped **in batch**.

### Votes
Voters queued by `CachedPost.Vote` matched against `active_votes`:
- requires `rshares >= 10e9`
- contribution `= int(1000 * ratio * rshares)`, ratio = payout/net_rshares — **bit-for-bit the legacy float math** (an initial test expectation of `$3.000` was wrong; Python computes `$2.999` for the same inputs — verified, Go matches)
- `contrib >= 20` ($0.02), dedup via existing vote notifs (type 17, batched)
- score `min(100, (digits-1)*25)` so $1 ≈ 75; payload `$X.XXX`; `when` = the vote's own timestamp

## Helpers
Account-id batch resolution; `isMuted`/`mutedTargets`; `existingMentions`/`existingVotes` (single IN queries); `defaultScore` backed by a lazily-loaded 1-based vote-weight rank map (legacy `fetch_ranks` thresholds <200→70, <1000→60, <6500→50, <25000→40, <100000→30, else 20).

## Wiring
`PostNotifs` installed on the CachedPost hook in `NewBlockProcessor`. `CachedPost` gains `PopPendingVoters`.

## Tests (Postgres 15)
- reply + mention emission with dedup on re-run
- vote payload/score/threshold (small votes skipped)
- mention spam cap (6 mentions over cap 5 → all skipped)

## Validation
`go build` / `go vet` / `go test ./...` all green.
