### PR TITLE
feat(indexer): implement CacheSync pruning and cache audit jobs (PR#8, KR4)

### DIFF
--- a/internal/indexer/cache_sync.go
+++ b/internal/indexer/cache_sync.go
@@ -1,0 +1,85 @@
+package indexer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/steemit/hivemind/pkg/logging"
+)
+
+// CacheSync prunes hive_posts_cache_temp of rows outside the 90-day hot
+// window. Port of hive/indexer/cache_sync.py.
+//
+// DELETE-only by design: orphan temp rows (post_id no longer in the main
+// cache) are removed at delete time by CachedPost.Delete and fork recovery;
+// the cold-start backfill happened once in migration v24.
+type CacheSync struct {
+	db     *gorm.DB
+	window time.Duration // tick interval
+	hotDay int           // retention window in days
+
+	syncing atomic.Bool
+	logger  *zap.Logger
+}
+
+// CacheSync defaults (legacy SYNC_WINDOW = 60s, HOT_DAYS = 90).
+const (
+	CacheSyncWindow  = 60 * time.Second
+	CacheSyncHotDays = 90
+)
+
+// NewCacheSync creates the temp-table pruner.
+func NewCacheSync(database *gorm.DB) *CacheSync {
+	return &CacheSync{
+		db:     database,
+		window: CacheSyncWindow,
+		hotDay: CacheSyncHotDays,
+		logger: logging.GetLogger().With(zap.String("component", "cache-sync")),
+	}
+}
+
+// Run ticks until ctx is cancelled, invoking Sync each window. Intended to
+// run as a background goroutine started by Sync.
+func (c *CacheSync) Run(ctx context.Context) {
+	ticker := time.NewTicker(c.window)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.Sync(ctx)
+		}
+	}
+}
+
+// Sync prunes out-of-window rows; non-blocking: skips if a run is active.
+func (c *CacheSync) Sync(ctx context.Context) {
+	if !c.syncing.CompareAndSwap(false, true) {
+		c.logger.Debug("previous sync still running, skip")
+		return
+	}
+	defer c.syncing.Store(false)
+	c.prune(ctx)
+}
+
+func (c *CacheSync) prune(ctx context.Context) {
+	cutoff := time.Now().UTC().AddDate(0, 0, -c.hotDay)
+	res := c.db.WithContext(ctx).
+		Exec("DELETE FROM hive_posts_cache_temp WHERE created_at < ?", cutoff)
+	if res.Error != nil {
+		c.logger.Error("prune failed", zap.Error(res.Error))
+		return
+	}
+	c.logger.Info("pruned temp rows outside hot window",
+		zap.Int64("deleted", res.RowsAffected),
+		zap.Time("cutoff", cutoff))
+}
+
+// syncMu guards the shared-instance helpers below (tests / manual triggers).
+var syncMu sync.Mutex

--- a/internal/indexer/jobs.go
+++ b/internal/indexer/jobs.go
@@ -1,0 +1,248 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/steemit/hivemind/internal/steem"
+	"github.com/steemit/hivemind/pkg/logging"
+)
+
+// Cache audit jobs. Port of hive/indexer/jobs.py — manual/periodic repair
+// tools keeping hive_posts and hive_posts_cache consistent:
+//   - AuditCacheMissing:  posts (not deleted) with no cache row → insert
+//   - AuditCacheDeleted:  deleted posts that still have a cache row → evict
+//   - AuditCacheUndelete: deleted posts that still exist on chain → restore
+
+// jobsBatchStep mirrors the legacy 1M-id batch stride.
+const jobsBatchStep = 1000000
+
+type cacheJobs struct {
+	db     *gorm.DB
+	cp     *CachedPost
+	steem  steem.Provider
+	logger *zap.Logger
+}
+
+// AuditCacheMissing scans for hive_posts rows (not deleted) with no cache
+// entry and queues them for insert, flushing per batch.
+func AuditCacheMissing(ctx context.Context, database *gorm.DB, cp *CachedPost) error {
+	j := &cacheJobs{db: database, cp: cp, logger: jobLogger()}
+	lastID, err := j.lastCachedPostID(ctx)
+	if err != nil {
+		return err
+	}
+	steps := int(lastID/jobsBatchStep) + 1
+	j.logger.Info("audit_cache_missing start", zap.Int64("last_cached_id", lastID), zap.Int("batches", steps))
+
+	for idx := 0; idx < steps; idx++ {
+		lbound, ubound := int64(idx*jobsBatchStep+1), int64((idx+1)*jobsBatchStep)
+		type row struct {
+			ID       int64
+			Author   string
+			Permlink string
+		}
+		var missing []row
+		if err := j.db.WithContext(ctx).
+			Table("hive_posts hp").
+			Select("hp.id", "hp.author", "hp.permlink").
+			Joins("LEFT JOIN hive_posts_cache hpc ON hp.id = hpc.post_id").
+			Where("hp.is_deleted = false AND hp.id BETWEEN ? AND ? AND hpc.post_id IS NULL", lbound, ubound).
+			Scan(&missing).Error; err != nil {
+			return err
+		}
+		for _, r := range missing {
+			cp.Insert(r.Author, r.Permlink, r.ID)
+		}
+		if len(missing) > 0 {
+			if _, err := cp.Flush(ctx, true); err != nil {
+				return fmt.Errorf("flush missing batch %d: %w", idx, err)
+			}
+		}
+		j.logger.Info("audit_cache_missing batch",
+			zap.Int64("lbound", lbound), zap.Int64("ubound", ubound),
+			zap.Int("missing", len(missing)))
+	}
+	return nil
+}
+
+// AuditCacheDeleted scans for deleted posts that still have cache entries
+// and evicts them from both cache tables.
+func AuditCacheDeleted(ctx context.Context, database *gorm.DB, cp *CachedPost) error {
+	j := &cacheJobs{db: database, cp: cp, logger: jobLogger()}
+	lastID, err := j.lastCachedPostID(ctx)
+	if err != nil {
+		return err
+	}
+	steps := int(lastID/jobsBatchStep) + 1
+	j.logger.Info("audit_cache_deleted start", zap.Int64("last_cached_id", lastID), zap.Int("batches", steps))
+
+	for idx := 0; idx < steps; idx++ {
+		lbound, ubound := int64(idx*jobsBatchStep+1), int64((idx+1)*jobsBatchStep)
+		type row struct {
+			ID       int64
+			Author   string
+			Permlink string
+		}
+		var extra []row
+		if err := j.db.WithContext(ctx).
+			Table("hive_posts hp").
+			Select("hp.id", "hp.author", "hp.permlink").
+			Joins("JOIN hive_posts_cache hpc ON hp.id = hpc.post_id").
+			Where("hp.is_deleted = true AND hp.id BETWEEN ? AND ?", lbound, ubound).
+			Scan(&extra).Error; err != nil {
+			return err
+		}
+		for _, r := range extra {
+			if err := cp.Delete(ctx, r.ID, r.Author, r.Permlink); err != nil {
+				return err
+			}
+		}
+		j.logger.Info("audit_cache_deleted batch",
+			zap.Int64("lbound", lbound), zap.Int64("ubound", ubound),
+			zap.Int("deleted", len(extra)))
+	}
+	return nil
+}
+
+// AuditCacheUndelete scans deleted posts, re-checks them on chain via
+// get_content_batch, and restores the ones steemd still serves
+// (mirrors legacy audit_cache_undelete + Posts.undelete).
+func AuditCacheUndelete(ctx context.Context, database *gorm.DB, cp *CachedPost, provider steem.Provider) error {
+	j := &cacheJobs{db: database, cp: cp, steem: provider, logger: jobLogger()}
+	lastID, err := j.lastPostID(ctx)
+	if err != nil {
+		return err
+	}
+	steps := int(lastID/jobsBatchStep) + 1
+	j.logger.Info("audit_cache_undelete start", zap.Int64("last_post_id", lastID), zap.Int("batches", steps))
+
+	for idx := 0; idx < steps; idx++ {
+		lbound, ubound := int64(idx*jobsBatchStep+1), int64((idx+1)*jobsBatchStep)
+		type row struct {
+			ID       int64
+			Author   string
+			Permlink string
+		}
+		var rows []row
+		if err := j.db.WithContext(ctx).
+			Table("hive_posts").
+			Select("id", "author", "permlink").
+			Where("is_deleted = true AND id BETWEEN ? AND ?", lbound, ubound).
+			Scan(&rows).Error; err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			continue
+		}
+
+		postArgs := make([][]string, len(rows))
+		for i, r := range rows {
+			postArgs[i] = []string{r.Author, r.Permlink}
+		}
+		posts, err := provider.GetContentBatch(ctx, postArgs)
+		if err != nil {
+			return err
+		}
+
+		recovered := 0
+		for i, r := range rows {
+			if getStr(posts[i], "author") == "" {
+				continue // still gone on chain
+			}
+			if err := j.undeletePost(ctx, posts[i], r.ID); err != nil {
+				j.logger.Warn("undelete failed", zap.Int64("id", r.ID), zap.Error(err))
+				continue
+			}
+			recovered++
+		}
+		j.logger.Info("audit_cache_undelete batch",
+			zap.Int64("lbound", lbound), zap.Int64("ubound", ubound),
+			zap.Int("recovered", recovered))
+		if recovered > 0 {
+			if _, err := cp.Flush(ctx, true); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// undeletePost restores a deleted hive_posts row from its on-chain state
+// (legacy Posts.undelete) and re-enters the cache pipeline.
+func (j *cacheJobs) undeletePost(ctx context.Context, post map[string]interface{}, pid int64) error {
+	author := getStr(post, "author")
+	permlink := getStr(post, "permlink")
+	category := getStr(post, "category")
+	depth, _ := numberInt(post["depth"])
+
+	updates := map[string]interface{}{
+		"is_deleted": false,
+		"is_pinned":  false,
+		"is_valid":   true,
+		"is_muted":   false,
+		"category":   category,
+		"depth":      depth,
+	}
+	// parent_id from the on-chain parent (comments).
+	if pa := getStr(post, "parent_author"); pa != "" {
+		if pp := getStr(post, "parent_permlink"); pp != "" {
+			var parentID int64
+			if err := j.db.WithContext(ctx).
+				Table("hive_posts").
+				Select("id").
+				Where("author = ? AND permlink = ?", pa, pp).
+				Scan(&parentID).Error; err == nil && parentID > 0 {
+				updates["parent_id"] = parentID
+			}
+		}
+	}
+	if created, err := ParseTime(getStr(post, "created")); err == nil {
+		updates["created_at"] = created
+	}
+
+	if err := j.db.WithContext(ctx).
+		Table("hive_posts").
+		Where("id = ?", pid).
+		Updates(updates).Error; err != nil {
+		return err
+	}
+	return j.cp.Undelete(ctx, pid, author, permlink, category)
+}
+
+func (j *cacheJobs) lastPostID(ctx context.Context) (int64, error) {
+	var id int64
+	err := j.db.WithContext(ctx).
+		Table("hive_posts").
+		Select("COALESCE(MAX(id), 0)").
+		Scan(&id).Error
+	return id, err
+}
+
+func (j *cacheJobs) lastCachedPostID(ctx context.Context) (int64, error) {
+	var id int64
+	err := j.db.WithContext(ctx).
+		Table("hive_posts_cache").
+		Select("COALESCE(MAX(post_id), 0)").
+		Scan(&id).Error
+	return id, err
+}
+
+func jobLogger() *zap.Logger {
+	return logging.GetLogger().With(zap.String("component", "cache-jobs"))
+}
+
+// RunCacheJobs executes all three audits in order; used by the optional
+// periodic scheduler and available for manual invocation.
+func RunCacheJobs(ctx context.Context, database *gorm.DB, cp *CachedPost, provider steem.Provider) error {
+	if err := AuditCacheMissing(ctx, database, cp); err != nil {
+		return err
+	}
+	if err := AuditCacheDeleted(ctx, database, cp); err != nil {
+		return err
+	}
+	return AuditCacheUndelete(ctx, database, cp, provider)
+}

--- a/internal/indexer/kr4_test.go
+++ b/internal/indexer/kr4_test.go
@@ -1,0 +1,156 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steemit/hivemind/internal/models"
+)
+
+func TestCacheSync_Prune(t *testing.T) {
+	database, _, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	old := time.Now().UTC().AddDate(0, 0, -100) // outside 90-day window
+	recent := time.Now().UTC().AddDate(0, 0, -1)
+	tx := database.DB.WithContext(ctx).Begin()
+	tx.Exec(`INSERT INTO hive_posts_cache_temp (post_id, author, permlink, created_at)
+	         VALUES (1, 'a', 'p1', ?), (2, 'a', 'p2', ?)`, old, recent)
+	tx.Commit()
+
+	cs := NewCacheSync(database.DB)
+	cs.Sync(ctx)
+
+	var n int64
+	database.DB.WithContext(ctx).Table("hive_posts_cache_temp").Count(&n)
+	if n != 1 {
+		t.Fatalf("temp rows after prune = %d, want 1 (recent kept)", n)
+	}
+	var pid int64
+	database.DB.WithContext(ctx).
+		Table("hive_posts_cache_temp").Select("post_id").Scan(&pid)
+	if pid != 2 {
+		t.Errorf("surviving row = %d, want 2", pid)
+	}
+}
+
+func TestAuditCacheMissing(t *testing.T) {
+	database, repo, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx := database.DB.WithContext(ctx).Begin()
+	tx.Create(&models.Account{Name: "alice", CreatedAt: time.Unix(1458845200, 0)})
+	tx.Commit()
+	post := &models.Post{Author: "alice", Permlink: "p1", Category: "life",
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), Depth: 0, IsValid: true}
+	database.DB.WithContext(ctx).Create(post)
+	// Note: no cache entry (simulating a lost write).
+
+	steemd := steemdPostFor("alice", "p1", "audited")
+	provider := &fakeSteemProvider{getContentBatch: func(_ context.Context, posts [][]string) ([]map[string]interface{}, error) {
+		out := make([]map[string]interface{}, len(posts))
+		for i := range posts {
+			out[i] = steemd
+		}
+		return out, nil
+	}}
+	cp := NewCachedPost(database.DB, provider)
+
+	if err := AuditCacheMissing(ctx, database.DB, cp); err != nil {
+		t.Fatalf("AuditCacheMissing: %v", err)
+	}
+
+	var main models.PostCache
+	if err := database.DB.WithContext(ctx).
+		Where("post_id = ?", post.ID).First(&main).Error; err != nil {
+		t.Fatalf("cache row missing after audit: %v", err)
+	}
+	if main.Body != "audited" {
+		t.Errorf("body = %q", main.Body)
+	}
+	_ = repo
+}
+
+func TestAuditCacheDeleted(t *testing.T) {
+	database, _, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx := database.DB.WithContext(ctx).Begin()
+	tx.Create(&models.Account{Name: "alice", CreatedAt: time.Unix(1458845200, 0)})
+	tx.Commit()
+	post := &models.Post{Author: "alice", Permlink: "p1", Category: "life",
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), Depth: 0,
+		IsValid: true, IsDeleted: true}
+	database.DB.WithContext(ctx).Create(post)
+
+	// Stale cache entry the deleted post should not have.
+	tx2 := database.DB.WithContext(ctx).Begin()
+	tx2.Exec(`INSERT INTO hive_posts_cache (post_id, author, permlink, created_at, updated_at)
+	          VALUES (?, 'alice', 'p1', '2026-01-02', '2026-01-02')`, post.ID)
+	tx2.Commit()
+
+	cp := NewCachedPost(database.DB, &fakeSteemProvider{})
+	if err := AuditCacheDeleted(ctx, database.DB, cp); err != nil {
+		t.Fatalf("AuditCacheDeleted: %v", err)
+	}
+
+	var n int64
+	database.DB.WithContext(ctx).
+		Table("hive_posts_cache").Where("post_id = ?", post.ID).Count(&n)
+	if n != 0 {
+		t.Errorf("stale cache rows = %d, want 0", n)
+	}
+}
+
+func TestAuditCacheUndelete(t *testing.T) {
+	database, _, cleanup := withMigratedDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx := database.DB.WithContext(ctx).Begin()
+	tx.Create(&models.Account{Name: "alice", CreatedAt: time.Unix(1458845200, 0)})
+	tx.Commit()
+	post := &models.Post{Author: "alice", Permlink: "p1", Category: "life",
+		CreatedAt: time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC), Depth: 0,
+		IsValid: true, IsDeleted: true}
+	database.DB.WithContext(ctx).Create(post)
+
+	// steemd still serves the post → it was erroneously deleted.
+	steemd := steemdPostFor("alice", "p1", "recovered body")
+	provider := &fakeSteemProvider{getContentBatch: func(_ context.Context, posts [][]string) ([]map[string]interface{}, error) {
+		out := make([]map[string]interface{}, len(posts))
+		for i := range posts {
+			out[i] = steemd
+		}
+		return out, nil
+	}}
+	cp := NewCachedPost(database.DB, provider)
+
+	if err := AuditCacheUndelete(ctx, database.DB, cp, provider); err != nil {
+		t.Fatalf("AuditCacheUndelete: %v", err)
+	}
+
+	// hive_posts restored.
+	var restored models.Post
+	database.DB.WithContext(ctx).Where("id = ?", post.ID).First(&restored)
+	if restored.IsDeleted {
+		t.Error("post still marked deleted")
+	}
+	if restored.Category != "life" {
+		t.Errorf("category = %q", restored.Category)
+	}
+
+	// Cache row restored via the undelete pipeline.
+	var main models.PostCache
+	if err := database.DB.WithContext(ctx).
+		Where("post_id = ?", post.ID).First(&main).Error; err != nil {
+		t.Fatalf("cache row not restored: %v", err)
+	}
+	if main.Body != "recovered body" {
+		t.Errorf("body = %q", main.Body)
+	}
+}

--- a/internal/indexer/sync.go
+++ b/internal/indexer/sync.go
@@ -60,12 +60,38 @@ func (s *Sync) Run(ctx context.Context) error {
 		s.logger.Info("Resuming normal sync")
 	}
 
+	// Prune hive_posts_cache_temp outside the 90-day hot window (60s tick).
+	go NewCacheSync(s.db.DB).Run(ctx)
+
+	// Optional periodic cache-consistency audits (0 = disabled; legacy runs
+	// these manually).
+	if interval := s.config.Indexer.JobsInterval; interval > 0 {
+		go s.runCacheJobsLoop(ctx, interval)
+	}
+
 	// Determine sync strategy based on configuration
 	// For now, we'll use Strategy B (irreversible blocks only)
 	// This is simpler and more reliable
 
 	// Start sync loop
 	return s.syncIrreversible(ctx)
+}
+
+// runCacheJobsLoop periodically runs the cache audit jobs.
+func (s *Sync) runCacheJobsLoop(ctx context.Context, intervalSec int) {
+	interval := time.Duration(intervalSec) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := RunCacheJobs(ctx, s.db.DB, s.blockProcessor.CachedPost(), s.steem); err != nil {
+				s.logger.Warn("cache jobs run failed", zap.Error(err))
+			}
+		}
+	}
 }
 
 // checkInitialSync checks if initial sync is needed by checking if feed cache is empty

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,11 @@ type IndexerConfig struct {
 	TestMaxBlock         int
 	TestDisableSync      bool
 	RecommendCommunities string
+
+	// JobsInterval is the cache-audit jobs period in seconds
+	// (audit_cache_missing/deleted/undelete). 0 disables the scheduler;
+	// the jobs remain available for manual invocation.
+	JobsInterval int
 }
 
 // LoggingConfig holds logging configuration
@@ -180,6 +185,7 @@ func Load() (*Config, error) {
 			TestMaxBlock:         getInt("test_max_block", 0),
 			TestDisableSync:      getBool("test_disable_sync", false),
 			RecommendCommunities: getString("recommend_communities", "hive-108451,hive-172186,hive-187187"),
+			JobsInterval:         getInt("jobs_interval", 0),
 		},
 		Logging: LoggingConfig{
 			Level:        getString("log_level", "INFO"),
@@ -224,6 +230,7 @@ func setDefaults() {
 	viper.SetDefault("log_format", "json")
 	viper.SetDefault("log_scalyr_format", true)
 	viper.SetDefault("trail_blocks", 2)
+	viper.SetDefault("jobs_interval", 0)
 	viper.SetDefault("max_batch", 50)
 	viper.SetDefault("max_workers", 4)
 	viper.SetDefault("telemetry_enabled", true)


### PR DESCRIPTION
## Summary

Implements **KR4**: the CacheSync temp-table pruner and the three cache audit jobs — the last indexer piece of the Q3 plan.

## CacheSync (`internal/indexer/cache_sync.go`)

Background goroutine pruning `hive_posts_cache_temp` of rows outside the **90-day hot window**, on a **60s tick** (legacy `SYNC_WINDOW`/`HOT_DAYS`). **DELETE-only by design** — orphan temp rows are handled at `CachedPost.Delete` time and the cold-start backfill happened once in migration v24. Non-blocking skip when a run overlaps (legacy threading semantics).

## Cache audit jobs (`internal/indexer/jobs.go`)

Ported from `jobs.py` with the legacy 1M-id batch stride:
- **AuditCacheMissing**: LEFT JOIN for non-deleted posts lacking a cache row → queue inserts + flush per batch
- **AuditCacheDeleted**: deleted posts that still have cache rows → evict via `CachedPost.Delete` (both tables + tags)
- **AuditCacheUndelete**: deleted posts re-checked on chain via `get_content_batch`; steemd-served posts are restored (`undeletePost` rebuilds the hive_posts row from on-chain state, then re-enters the cache pipeline through `CachedPost.Undelete`)

## Sync wiring

CacheSync runs alongside the sync loop. The audit jobs get an **optional periodic scheduler** behind `HIVE_JOBS_INTERVAL` (0 = disabled — matching legacy where they are manual tools; registered in `Load()` + `setDefaults()` per AGENTS.md). `RunCacheJobs` is exported for manual invocation.

## Tests (Postgres 15)
- prune keeps recent / deletes old temp rows
- missing entry inserted by audit
- stale deleted entry evicted
- erroneously-deleted post restored **end to end** (hive_posts flags + cache row)

## Validation
`go build` / `go vet` / `go test ./...` all green.
