### PR TITLE
fix(api): short-tag panic and ambiguous post_id in cursor queries

### DIFF
--- a/internal/api/condenser/cursor.go
+++ b/internal/api/condenser/cursor.go
@@ -3,6 +3,7 @@ package condenser
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"gorm.io/gorm"
 
@@ -27,7 +28,7 @@ func (c *Cursor) GetPostIDByAuthorPermlink(ctx context.Context, author, permlink
 		Where("author = ? AND permlink = ?", author, permlink).
 		Select("id").
 		First(&post).Error
-	
+
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return 0, nil
@@ -45,7 +46,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 		"hot":             true,
 		"created":         true,
 		"promoted":        true,
-		"payout":           true,
+		"payout":          true,
 		"payout_comments": true,
 	}
 	if !validSorts[sort] {
@@ -55,7 +56,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 	// Build query based on sort type
 	query := c.db.WithContext(ctx).
 		Model(&models.PostCache{}).
-		Select("post_id")
+		Select("hive_posts_cache.post_id")
 
 	// Apply filters based on sort type
 	switch sort {
@@ -67,7 +68,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 			Order("sc_hot DESC")
 	case "created":
 		query = query.Where("depth = ?", 0).
-			Order("post_id DESC")
+			Order("hive_posts_cache.post_id DESC")
 	case "promoted":
 		query = query.Where("is_paidout = ? AND promoted > ?", false, 0).
 			Order("promoted DESC")
@@ -81,7 +82,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 
 	// Filter by tag if provided
 	if tag != "" {
-		if tag[:5] == "hive-" {
+		if strings.HasPrefix(tag, "hive-") {
 			// Community tag
 			query = query.Where("category = ?", tag)
 			if sort == "trending" || sort == "hot" {
@@ -128,7 +129,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 			case "hot":
 				query = query.Where("sc_hot <= ?", startValue)
 			case "created", "payout", "payout_comments":
-				query = query.Where("post_id <= ?", startValue)
+				query = query.Where("hive_posts_cache.post_id <= ?", startValue)
 			}
 		}
 	}
@@ -205,4 +206,3 @@ func (c *Cursor) GetPostIDsByBlog(ctx context.Context, account string, startAuth
 
 	return ids, nil
 }
-


### PR DESCRIPTION
## Summary

Two bugs found by the **end-to-end smoke test** (Q3 milestone verification: live server binary + seeded data + curl JSON-RPC). Both hit `get_discussions_by_trending` with a regular tag.

### 1. Short-tag panic (crash)
```go
if tag[:5] == "hive-"   // tag "life" (4 chars) → slice bounds out of range
```
Any tag shorter than 5 chars panicked the handler (gin.Recovery caught it as a 500). Fixed with `strings.HasPrefix` — the equivalent pattern in `hive/notify.go` was already guarded.

### 2. Ambiguous `post_id` (SQLSTATE 42702)
With the tag join (`hive_post_tags`), `SELECT post_id` / `ORDER BY post_id` / `post_id <= ?` were ambiguous between `hive_posts_cache` and `hive_post_tags`. All references in `GetPostIDsByQuery` are now table-qualified.

## Verified live (after fix)
- trending **without tag**: 4 seeded posts, sorted by sc_trend, parsed 4-field active_votes
- trending **tag=life** (join path): tagged root returned
- **short tags: HTTP 200** (was 500/panic)
- `bridge.get_account_posts` feed sort: explicit not-implemented error (no crash — #388 regression verified live)

## Validation
`go build` / `go vet` / `go test ./...` all green.