### PR TITLE
fix(api): sanitize JSON-RPC errors, validate get_discussion input, clamp limits

### DIFF
--- a/internal/api/bridge/post.go
+++ b/internal/api/bridge/post.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -28,7 +29,7 @@ func (p *PostAPI) GetPost(ctx *gin.Context, params json.RawMessage) (interface{}
 
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	author, _ := pMap["author"].(string)
@@ -41,7 +42,7 @@ func (p *PostAPI) GetPost(ctx *gin.Context, params json.RawMessage) (interface{}
 	})
 
 	if author == "" || permlink == "" {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
 	}
 
 	postRepo := db.NewPostRepository(p.repo)
@@ -145,7 +146,7 @@ func (p *PostAPI) GetPostHeader(ctx *gin.Context, params json.RawMessage) (inter
 
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	author, _ := pMap["author"].(string)
@@ -157,7 +158,7 @@ func (p *PostAPI) GetPostHeader(ctx *gin.Context, params json.RawMessage) (inter
 	})
 
 	if author == "" || permlink == "" {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
 	}
 
 	postRepo := db.NewPostRepository(p.repo)
@@ -228,7 +229,7 @@ func (p *PostAPI) GetDiscussion(ctx *gin.Context, params json.RawMessage) (inter
 
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	author, _ := pMap["author"].(string)
@@ -242,7 +243,15 @@ func (p *PostAPI) GetDiscussion(ctx *gin.Context, params json.RawMessage) (inter
 	})
 
 	if author == "" || permlink == "" {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
+	}
+	// Input validation (legacy helpers.valid_account/valid_permlink) —
+	// rejects malformed names before any DB access.
+	if _, err := apierrors.ValidAccount(author, false); err != nil {
+		return nil, err
+	}
+	if _, err := apierrors.ValidPermlink(permlink, false); err != nil {
+		return nil, err
 	}
 
 	// Sub-span: resolve root post ID.

--- a/internal/api/bridge/profile.go
+++ b/internal/api/bridge/profile.go
@@ -2,7 +2,7 @@ package bridge
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -23,14 +23,14 @@ func NewProfileAPI(repo *db.Repository) *ProfileAPI {
 func (pr *ProfileAPI) GetProfile(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	observer, _ := pMap["observer"].(string)
 
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	accountRepo := db.NewAccountRepository(pr.repo)
@@ -46,17 +46,16 @@ func (pr *ProfileAPI) GetProfile(ctx *gin.Context, params json.RawMessage) (inte
 	_ = observer
 
 	return map[string]interface{}{
-		"id":          acc.ID,
-		"name":        acc.Name,
-		"display_name": acc.DisplayName.String,
-		"about":       acc.About.String,
-		"location":    acc.Location.String,
-		"website":     acc.Website.String,
+		"id":            acc.ID,
+		"name":          acc.Name,
+		"display_name":  acc.DisplayName.String,
+		"about":         acc.About.String,
+		"location":      acc.Location.String,
+		"website":       acc.Website.String,
 		"profile_image": acc.ProfileImage,
 		"cover_image":   acc.CoverImage,
-		"followers":    acc.Followers,
-		"following":    acc.Following,
-		"reputation":   acc.Reputation,
+		"followers":     acc.Followers,
+		"following":     acc.Following,
+		"reputation":    acc.Reputation,
 	}, nil
 }
-

--- a/internal/api/bridge/ranked.go
+++ b/internal/api/bridge/ranked.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -32,12 +33,12 @@ func NewRankedAPI(repo *db.Repository, database *db.DB, redisCache *cache.Cache)
 func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	sort, _ := pMap["sort"].(string)
 	if sort == "" {
-		return nil, fmt.Errorf("missing required parameter: sort")
+		return nil, apierrors.PublicError("missing required parameter: sort")
 	}
 
 	startAuthor := ""
@@ -94,7 +95,7 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 
 	querySort, ok := sortMap[sort]
 	if !ok {
-		return nil, fmt.Errorf("invalid sort type: %s", sort)
+		return nil, apierrors.Publicf("invalid sort type: %s", sort)
 	}
 
 	// Get post IDs
@@ -144,17 +145,17 @@ func (r *RankedAPI) getCacheTTL(sort string) time.Duration {
 func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	sort, _ := pMap["sort"].(string)
 	if sort == "" {
-		return nil, fmt.Errorf("missing required parameter: sort")
+		return nil, apierrors.PublicError("missing required parameter: sort")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	startAuthor := ""
@@ -190,7 +191,7 @@ func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (i
 		// TODO: Implement personalized feed (follows join feed_cache, see
 		// legacy pids_by_feed_with_reblog). Must NOT delegate to self with
 		// unchanged params — that is infinite recursion (stack overflow).
-		return nil, fmt.Errorf("feed sort is not implemented")
+		return nil, apierrors.PublicError("feed sort is not implemented")
 	case "posts":
 		// Author's posts only (no reblogs)
 		// TODO: Implement
@@ -215,7 +216,7 @@ func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (i
 		}
 		return result, nil
 	default:
-		return nil, fmt.Errorf("invalid sort type: %s", sort)
+		return nil, apierrors.Publicf("invalid sort type: %s", sort)
 	}
 }
 
@@ -223,7 +224,7 @@ func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (i
 func (r *RankedAPI) GetTrendingTopics(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	limit := 10

--- a/internal/api/bridge/stats.go
+++ b/internal/api/bridge/stats.go
@@ -2,7 +2,7 @@ package bridge
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -38,7 +38,7 @@ func (s *StatsAPI) GetPayoutStats(ctx *gin.Context, params json.RawMessage) (int
 
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	// Extract parameters

--- a/internal/api/condenser/blog.go
+++ b/internal/api/condenser/blog.go
@@ -2,7 +2,7 @@ package condenser
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -31,7 +31,7 @@ func (b *BlogAPI) GetBlog(ctx *gin.Context, params json.RawMessage) (interface{}
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	account, _ := p[0].(string)
@@ -89,5 +89,5 @@ func (b *BlogAPI) GetBlogEntries(ctx *gin.Context, params json.RawMessage) (inte
 	// TODO: Implement (legacy returns a LIGHTWEIGHT shape: {blog, entry_id,
 	// author, permlink, reblog_on} — delegating to GetBlog would return full
 	// post objects, which is the wrong response shape).
-	return nil, fmt.Errorf("not implemented")
+	return nil, apierrors.PublicError("not implemented")
 }

--- a/internal/api/condenser/content.go
+++ b/internal/api/condenser/content.go
@@ -2,7 +2,7 @@ package condenser
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -14,8 +14,8 @@ import (
 
 // ContentAPI provides content-related API methods
 type ContentAPI struct {
-	repo      *db.Repository
-	database  *gorm.DB
+	repo       *db.Repository
+	database   *gorm.DB
 	postLoader *objects.PostLoader
 }
 
@@ -41,7 +41,7 @@ func (c *ContentAPI) GetContent(ctx *gin.Context, params json.RawMessage) (inter
 	}
 
 	if len(p) < 2 {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
 	}
 
 	author, _ := p[0].(string)
@@ -84,7 +84,7 @@ func (c *ContentAPI) GetContentReplies(ctx *gin.Context, params json.RawMessage)
 	}
 
 	if len(p) < 2 {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
 	}
 
 	author, _ := p[0].(string)
@@ -130,4 +130,3 @@ func (c *ContentAPI) GetContentReplies(ctx *gin.Context, params json.RawMessage)
 
 	return posts, nil
 }
-

--- a/internal/api/condenser/cursor.go
+++ b/internal/api/condenser/cursor.go
@@ -2,7 +2,7 @@ package condenser
 
 import (
 	"context"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"strings"
 
 	"gorm.io/gorm"
@@ -50,7 +50,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 		"payout_comments": true,
 	}
 	if !validSorts[sort] {
-		return nil, fmt.Errorf("invalid sort type: %s", sort)
+		return nil, apierrors.Publicf("invalid sort type: %s", sort)
 	}
 
 	// Build query based on sort type
@@ -134,8 +134,9 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 		}
 	}
 
-	// Apply limit
-	query = query.Limit(limit)
+	// Apply limit (clamped: a negative SQL LIMIT is treated as unbounded,
+	// which would full-scan the cache table).
+	query = query.Limit(apierrors.ClampLimit(limit))
 
 	// Execute query
 	var results []struct {
@@ -190,7 +191,7 @@ func (c *Cursor) GetPostIDsByBlog(ctx context.Context, account string, startAuth
 		}
 	}
 
-	query = query.Order("created_at DESC").Limit(limit)
+	query = query.Order("created_at DESC").Limit(apierrors.ClampLimit(limit))
 
 	var results []struct {
 		PostID int64 `gorm:"column:post_id"`

--- a/internal/api/condenser/discussions.go
+++ b/internal/api/condenser/discussions.go
@@ -2,7 +2,7 @@ package condenser
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -54,7 +54,7 @@ func (d *DiscussionsAPI) getDiscussionsBySort(ctx *gin.Context, sort string, par
 		// Try array format
 		var arr []interface{}
 		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, fmt.Errorf("invalid parameters format")
+			return nil, apierrors.PublicError("invalid parameters format")
 		}
 		// Convert array to map (legacy format)
 		p = make(map[string]interface{})
@@ -111,7 +111,7 @@ func (d *DiscussionsAPI) GetDiscussionsByBlog(ctx *gin.Context, params json.RawM
 	if err := json.Unmarshal(params, &p); err != nil {
 		var arr []interface{}
 		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, fmt.Errorf("invalid parameters format")
+			return nil, apierrors.PublicError("invalid parameters format")
 		}
 		if len(arr) > 0 {
 			if m, ok := arr[0].(map[string]interface{}); ok {
@@ -143,7 +143,7 @@ func (d *DiscussionsAPI) GetDiscussionsByBlog(ctx *gin.Context, params json.RawM
 	// tag parameter is actually the account name for blog queries
 	account := tag
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: tag (account name)")
+		return nil, apierrors.PublicError("missing required parameter: tag (account name)")
 	}
 
 	// Get post IDs from feed cache
@@ -171,5 +171,5 @@ func (d *DiscussionsAPI) GetDiscussionsByFeed(ctx *gin.Context, params json.RawM
 	// TODO: Implement personalized feed (follows join feed_cache, see legacy
 	// pids_by_feed_with_reblog). Must NOT silently return blog results —
 	// feed and blog are different result sets.
-	return nil, fmt.Errorf("not implemented")
+	return nil, apierrors.PublicError("not implemented")
 }

--- a/internal/api/condenser/follow.go
+++ b/internal/api/condenser/follow.go
@@ -3,6 +3,7 @@ package condenser
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -34,7 +35,7 @@ func (f *FollowAPI) GetFollowers(c *gin.Context, params json.RawMessage) (interf
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	account, _ := p[0].(string)
@@ -122,7 +123,7 @@ func (f *FollowAPI) GetFollowing(c *gin.Context, params json.RawMessage) (interf
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	account, _ := p[0].(string)
@@ -210,7 +211,7 @@ func (f *FollowAPI) GetFollowCount(c *gin.Context, params json.RawMessage) (inte
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	account, _ := p[0].(string)
@@ -225,7 +226,7 @@ func (f *FollowAPI) GetFollowCount(c *gin.Context, params json.RawMessage) (inte
 	}
 
 	return map[string]interface{}{
-		"account":        account,
+		"account":         account,
 		"following_count": acc.Following,
 		"follower_count":  acc.Followers,
 	}, nil
@@ -239,7 +240,7 @@ func (f *FollowAPI) GetRebloggedBy(c *gin.Context, params json.RawMessage) (inte
 	}
 
 	if len(p) < 2 {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
 	}
 
 	author, _ := p[0].(string)
@@ -434,4 +435,3 @@ func (f *FollowAPI) GetFollowingByPage(c *gin.Context, params json.RawMessage) (
 
 	return result, nil
 }
-

--- a/internal/api/condenser/misc.go
+++ b/internal/api/condenser/misc.go
@@ -3,6 +3,7 @@ package condenser
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -29,7 +30,7 @@ func (m *MiscAPI) GetDiscussionsByComments(ctx *gin.Context, params json.RawMess
 	if err := json.Unmarshal(params, &p); err != nil {
 		var arr []interface{}
 		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, fmt.Errorf("invalid parameters format")
+			return nil, apierrors.PublicError("invalid parameters format")
 		}
 		if len(arr) > 0 {
 			if mp, ok := arr[0].(map[string]interface{}); ok {
@@ -73,7 +74,7 @@ func (m *MiscAPI) GetRepliesByLastUpdate(ctx *gin.Context, params json.RawMessag
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: start_author")
+		return nil, apierrors.PublicError("missing required parameter: start_author")
 	}
 
 	startAuthor, _ := p[0].(string)
@@ -107,7 +108,7 @@ func (m *MiscAPI) GetDiscussionsByAuthorBeforeDate(ctx *gin.Context, params json
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: author")
+		return nil, apierrors.PublicError("missing required parameter: author")
 	}
 
 	author, _ := p[0].(string)
@@ -157,7 +158,7 @@ func (m *MiscAPI) getDiscussionsByPayout(ctx *gin.Context, params json.RawMessag
 	if err := json.Unmarshal(params, &p); err != nil {
 		var arr []interface{}
 		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, fmt.Errorf("invalid parameters format")
+			return nil, apierrors.PublicError("invalid parameters format")
 		}
 		if len(arr) > 0 {
 			if mp, ok := arr[0].(map[string]interface{}); ok {
@@ -215,7 +216,7 @@ func (m *MiscAPI) GetTransaction(ctx *gin.Context, params json.RawMessage) (inte
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: trx_id")
+		return nil, apierrors.PublicError("missing required parameter: trx_id")
 	}
 
 	trxID, _ := p[0].(string)
@@ -235,7 +236,7 @@ func (m *MiscAPI) GetState(ctx *gin.Context, params json.RawMessage) (interface{
 	}
 
 	if len(p) < 1 {
-		return nil, fmt.Errorf("missing required parameter: path")
+		return nil, apierrors.PublicError("missing required parameter: path")
 	}
 
 	path, _ := p[0].(string)
@@ -256,6 +257,5 @@ func (m *MiscAPI) GetState(ctx *gin.Context, params json.RawMessage) (interface{
 // GetAccountVotes handles condenser_api.get_account_votes (dummy method)
 func (m *MiscAPI) GetAccountVotes(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	// This method is no longer supported
-	return nil, fmt.Errorf("get_account_votes is no longer supported")
+	return nil, apierrors.PublicError("get_account_votes is no longer supported")
 }
-

--- a/internal/api/condenser/tags.go
+++ b/internal/api/condenser/tags.go
@@ -98,4 +98,3 @@ func (t *TagsAPI) GetAccountReputations(ctx *gin.Context, params json.RawMessage
 		"reputations": reputations,
 	}, nil
 }
-

--- a/internal/api/hive/community.go
+++ b/internal/api/hive/community.go
@@ -3,6 +3,7 @@ package hive
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -23,12 +24,12 @@ func NewCommunityAPI(repo *db.Repository) *CommunityAPI {
 func (c *CommunityAPI) GetCommunity(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	name, _ := pMap["name"].(string)
 	if name == "" {
-		return nil, fmt.Errorf("missing required parameter: name")
+		return nil, apierrors.PublicError("missing required parameter: name")
 	}
 
 	// TODO: Query community from hive_communities
@@ -43,7 +44,7 @@ func (c *CommunityAPI) GetCommunity(ctx *gin.Context, params json.RawMessage) (i
 func (c *CommunityAPI) GetCommunityContext(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	name, _ := pMap["name"].(string)
@@ -65,7 +66,7 @@ func (c *CommunityAPI) GetCommunityContext(ctx *gin.Context, params json.RawMess
 func (c *CommunityAPI) ListCommunities(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	last := ""
@@ -97,7 +98,7 @@ func (c *CommunityAPI) ListTopCommunities(ctx *gin.Context, params json.RawMessa
 func (c *CommunityAPI) ListPopCommunities(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	limit := 25
@@ -118,12 +119,12 @@ func (c *CommunityAPI) ListPopCommunities(ctx *gin.Context, params json.RawMessa
 func (c *CommunityAPI) ListCommunityRoles(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	community, _ := pMap["community"].(string)
 	if community == "" {
-		return nil, fmt.Errorf("missing required parameter: community")
+		return nil, apierrors.PublicError("missing required parameter: community")
 	}
 
 	// TODO: Query roles from hive_roles
@@ -136,12 +137,12 @@ func (c *CommunityAPI) ListCommunityRoles(ctx *gin.Context, params json.RawMessa
 func (c *CommunityAPI) ListSubscribers(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	community, _ := pMap["community"].(string)
 	if community == "" {
-		return nil, fmt.Errorf("missing required parameter: community")
+		return nil, apierrors.PublicError("missing required parameter: community")
 	}
 
 	// TODO: Query subscribers from hive_subscriptions
@@ -154,12 +155,12 @@ func (c *CommunityAPI) ListSubscribers(ctx *gin.Context, params json.RawMessage)
 func (c *CommunityAPI) ListAllSubscriptions(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	// TODO: Query subscriptions from hive_subscriptions
@@ -167,4 +168,3 @@ func (c *CommunityAPI) ListAllSubscriptions(ctx *gin.Context, params json.RawMes
 
 	return []interface{}{}, nil
 }
-

--- a/internal/api/hive/notify.go
+++ b/internal/api/hive/notify.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -27,14 +27,14 @@ func NewNotifyAPI(repo *db.Repository) *NotifyAPI {
 func (n *NotifyAPI) PostNotifications(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	author, _ := pMap["author"].(string)
 	permlink, _ := pMap["permlink"].(string)
 
 	if author == "" || permlink == "" {
-		return nil, fmt.Errorf("missing required parameters: author, permlink")
+		return nil, apierrors.PublicError("missing required parameters: author, permlink")
 	}
 
 	minScore := int16(25)
@@ -77,12 +77,12 @@ func (n *NotifyAPI) PostNotifications(ctx *gin.Context, params json.RawMessage) 
 func (n *NotifyAPI) AccountNotifications(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	minScore := int16(25)
@@ -135,12 +135,12 @@ func (n *NotifyAPI) AccountNotifications(ctx *gin.Context, params json.RawMessag
 func (n *NotifyAPI) UnreadNotifications(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	minScore := int16(25)
@@ -378,4 +378,3 @@ func findSubstring(s, substr string, start int) int {
 	}
 	return -1
 }
-

--- a/internal/api/hive/public.go
+++ b/internal/api/hive/public.go
@@ -3,6 +3,7 @@ package hive
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -23,14 +24,14 @@ func NewPublicAPI(repo *db.Repository) *PublicAPI {
 func (p *PublicAPI) GetAccount(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	name, _ := pMap["name"].(string)
 	observer, _ := pMap["observer"].(string)
 
 	if name == "" {
-		return nil, fmt.Errorf("missing required parameter: name")
+		return nil, apierrors.PublicError("missing required parameter: name")
 	}
 
 	accountRepo := db.NewAccountRepository(p.repo)
@@ -60,7 +61,7 @@ func (p *PublicAPI) GetAccount(ctx *gin.Context, params json.RawMessage) (interf
 func (p *PublicAPI) GetAccounts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	namesInterface, ok := pMap["names"].([]interface{})
@@ -98,12 +99,12 @@ func (p *PublicAPI) GetAccounts(ctx *gin.Context, params json.RawMessage) (inter
 func (p *PublicAPI) ListFollowers(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	start := ""
@@ -130,19 +131,19 @@ func (p *PublicAPI) ListFollowing(ctx *gin.Context, params json.RawMessage) (int
 	// TODO: Implement (query hive_follows in the following direction).
 	// Must NOT delegate to ListFollowers — different semantics, would return
 	// wrong data.
-	return nil, fmt.Errorf("not implemented")
+	return nil, apierrors.PublicError("not implemented")
 }
 
 // ListAllMuted handles hive_api.list_all_muted
 func (p *PublicAPI) ListAllMuted(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	// TODO: Query muted accounts from hive_follows where state includes ignore
@@ -153,12 +154,12 @@ func (p *PublicAPI) ListAllMuted(ctx *gin.Context, params json.RawMessage) (inte
 func (p *PublicAPI) ListAccountBlog(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, fmt.Errorf("invalid parameters format")
+		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
-		return nil, fmt.Errorf("missing required parameter: account")
+		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
 	limit := 10
@@ -179,12 +180,12 @@ func (p *PublicAPI) ListAccountBlog(ctx *gin.Context, params json.RawMessage) (i
 func (p *PublicAPI) ListAccountPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	// TODO: Implement (author's own posts only, no reblogs).
 	// Must NOT delegate to ListAccountBlog — different semantics.
-	return nil, fmt.Errorf("not implemented")
+	return nil, apierrors.PublicError("not implemented")
 }
 
 // ListAccountFeed handles hive_api.list_account_feed
 func (p *PublicAPI) ListAccountFeed(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	// TODO: Implement (personalized feed from follows).
 	// Must NOT delegate to ListAccountBlog — different semantics.
-	return nil, fmt.Errorf("not implemented")
+	return nil, apierrors.PublicError("not implemented")
 }

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/pkg/logging"
 	"github.com/steemit/hivemind/pkg/telemetry"
 )
@@ -27,9 +28,9 @@ type JSONRPCRequest struct {
 
 // JSONRPCResponse represents a JSON-RPC 2.0 response
 type JSONRPCResponse struct {
-	JSONRPC string       `json:"jsonrpc"`
-	ID      interface{}  `json:"id"`
-	Result  interface{}  `json:"result,omitempty"`
+	JSONRPC string        `json:"jsonrpc"`
+	ID      interface{}   `json:"id"`
+	Result  interface{}   `json:"result,omitempty"`
 	Error   *JSONRPCError `json:"error,omitempty"`
 }
 
@@ -92,7 +93,7 @@ func (h *JSONRPCHandler) Handle(c *gin.Context) {
 	// Validate JSON-RPC version
 	if req.JSONRPC != "2.0" {
 		telemetry.RecordError("jsonrpc", req.Method, "invalid_request")
-		h.sendError(c, req.ID, -32600, "Invalid Request", fmt.Errorf("invalid jsonrpc version"))
+		h.sendError(c, req.ID, -32600, "Invalid Request", apierrors.PublicError("invalid jsonrpc version"))
 		return
 	}
 
@@ -107,7 +108,7 @@ func (h *JSONRPCHandler) Handle(c *gin.Context) {
 	handler, ok := h.methods[req.Method]
 	if !ok {
 		telemetry.RecordError(namespace, method, "method_not_found")
-		h.sendError(c, req.ID, -32601, "Method not found", fmt.Errorf("method %s not found", req.Method))
+		h.sendError(c, req.ID, -32601, "Method not found", apierrors.Publicf("method %s not found", req.Method))
 		return
 	}
 
@@ -181,8 +182,15 @@ func (h *JSONRPCHandler) sendError(c *gin.Context, id interface{}, code int, mes
 		Error: &JSONRPCError{
 			Code:    code,
 			Message: message,
-			Data:    err.Error(),
 		},
+	}
+	// Sanitize: only PublicError messages (input validation, documented
+	// refusals) are safe for the client. Internal errors (SQL details,
+	// file paths, stack fragments) are withheld — the full error is
+	// already logged and recorded on the span above.
+	var pub apierrors.PublicError
+	if errors.As(err, &pub) {
+		resp.Error.Data = pub.Error()
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/internal/apierrors/errors.go
+++ b/internal/apierrors/errors.go
@@ -1,0 +1,89 @@
+// Package apierrors defines the error contract for JSON-RPC handlers:
+// PublicError messages are safe to return to clients; any other error is
+// logged and traced but its detail is withheld from the response
+// (sanitized) so internal SQL/stack details never leak.
+//
+// It also ports the legacy input validators (hive/server/common/helpers.py
+// valid_account/valid_permlink/valid_limit) with identical semantics.
+package apierrors
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// PublicError is an error whose message is safe for client consumption.
+// Handlers return these for user-input problems and documented refusals
+// (e.g. "not implemented"); the JSON-RPC layer forwards the message in
+// error.data.
+type PublicError string
+
+// Error implements the error interface.
+func (e PublicError) Error() string { return string(e) }
+
+// Publicf formats a new PublicError.
+func Publicf(format string, args ...interface{}) PublicError {
+	return PublicError(fmt.Sprintf(format, args...))
+}
+
+// accountNameRe matches valid steem account names (legacy valid_account).
+var accountNameRe = regexp.MustCompile(`^[a-z0-9\.\-]+$`)
+
+// ValidAccount validates a steem account name (3-16 chars, lowercase
+// alnum plus . and -, no leading @). Mirrors legacy valid_account; the
+// returned error is a PublicError.
+func ValidAccount(name string, allowEmpty bool) (string, error) {
+	if name == "" {
+		if !allowEmpty {
+			return "", PublicError("invalid account (not specified)")
+		}
+		return "", nil
+	}
+	if len(name) < 3 || len(name) > 16 {
+		return "", Publicf("invalid account name length: `%s`", name)
+	}
+	if name[0] == '@' {
+		return "", Publicf("invalid account name char `@`")
+	}
+	if !accountNameRe.MatchString(name) {
+		return "", Publicf("invalid account char in `%s`", name)
+	}
+	return name, nil
+}
+
+// ValidPermlink validates a permlink (string, ≤256 chars). Mirrors legacy
+// valid_permlink.
+func ValidPermlink(permlink string, allowEmpty bool) (string, error) {
+	if permlink == "" {
+		if !allowEmpty {
+			return "", PublicError("permlink cannot be blank")
+		}
+		return "", nil
+	}
+	if len(permlink) > 256 {
+		return "", PublicError("invalid permlink length")
+	}
+	return permlink, nil
+}
+
+// ValidLimit validates a user-provided limit: positive and within ubound.
+// Mirrors legacy valid_limit.
+func ValidLimit(limit int, ubound int) (int, error) {
+	if limit <= 0 {
+		return 0, PublicError("limit must be positive")
+	}
+	if limit > ubound {
+		return 0, Publicf("limit exceeds max (%d > %d)", limit, ubound)
+	}
+	return limit, nil
+}
+
+// ClampLimit is the defensive counterpart used at query boundaries: any
+// non-positive limit collapses to 0 (an empty result — never an unbounded
+// table scan, which is what a negative SQL LIMIT would produce).
+func ClampLimit(limit int) int {
+	if limit < 0 {
+		return 0
+	}
+	return limit
+}

--- a/internal/apierrors/errors_test.go
+++ b/internal/apierrors/errors_test.go
@@ -1,0 +1,90 @@
+package apierrors
+
+import (
+	"testing"
+)
+
+func TestValidAccount(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		allowEmpty bool
+		wantErr    bool
+	}{
+		{"valid", "alice", false, false},
+		{"with dot/dash", "a.b-c", false, false},
+		{"empty not allowed", "", false, true},
+		{"empty allowed", "", true, false},
+		{"too short", "ab", false, true},
+		{"too long", "abcdefghijklmnopq", false, true},
+		{"leading at", "@alice", false, true},
+		{"uppercase", "Alice", false, true},
+		{"bad char", "bad:name", false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ValidAccount(c.in, c.allowEmpty)
+			if c.wantErr && err == nil {
+				t.Errorf("ValidAccount(%q) should fail", c.in)
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("ValidAccount(%q) = %v", c.in, err)
+			}
+			if err != nil {
+				if _, ok := err.(PublicError); !ok {
+					t.Errorf("error should be PublicError, got %T", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidPermlink(t *testing.T) {
+	if _, err := ValidPermlink("ok-permlink", false); err != nil {
+		t.Errorf("valid permlink failed: %v", err)
+	}
+	if _, err := ValidPermlink("", false); err == nil {
+		t.Error("blank permlink should fail")
+	}
+	if _, err := ValidPermlink("", true); err != nil {
+		t.Error("blank allowed should pass")
+	}
+	long := make([]byte, 257)
+	for i := range long {
+		long[i] = 'x'
+	}
+	if _, err := ValidPermlink(string(long), false); err == nil {
+		t.Error("oversized permlink should fail")
+	}
+}
+
+func TestValidLimitAndClamp(t *testing.T) {
+	if _, err := ValidLimit(20, 100); err != nil {
+		t.Errorf("valid limit failed: %v", err)
+	}
+	if _, err := ValidLimit(-5, 100); err == nil {
+		t.Error("negative limit should fail")
+	}
+	if _, err := ValidLimit(0, 100); err == nil {
+		t.Error("zero limit should fail")
+	}
+	if _, err := ValidLimit(101, 100); err == nil {
+		t.Error("over-limit should fail")
+	}
+	if ClampLimit(-5) != 0 {
+		t.Error("ClampLimit(-5) should be 0")
+	}
+	if ClampLimit(0) != 0 {
+		t.Error("ClampLimit(0) should be 0")
+	}
+	if ClampLimit(50) != 50 {
+		t.Error("ClampLimit(50) should be 50")
+	}
+}
+
+func TestPublicErrorFormatting(t *testing.T) {
+	e := Publicf("limit exceeds max (%d > %d)", 101, 100)
+	if e.Error() != "limit exceeds max (101 > 100)" {
+		t.Errorf("Publicf = %q", e.Error())
+	}
+}


### PR DESCRIPTION
## Summary

**Gray-release preflight hardening** — the remaining code items from the 2026-08-16 audit checklist (`0821.md` TODO: 切流前完成审计遗留修复). With this merged, `bridge.get_discussion` is ready for jussi method-level routing.

## 1. JSON-RPC error sanitization

`error.data` previously leaked raw internal error strings (SQL fragments, file paths) to clients.

New contract: handlers signal client-safe messages via `apierrors.PublicError`; `sendError` forwards **only those** in `data` and withholds everything else (the full error stays in logs + OTel span).

**71 input-validation refusals** across bridge/condenser/hive upgraded to PublicError: invalid params, missing parameters, invalid sort, `not implemented`, method not found, unsupported methods.

## 2. get_discussion input validation

`author`/`permlink` validated **before any DB access** — ports of the legacy `helpers.valid_account` (3–16 chars, `[a-z0-9.-]`, no leading `@`) and `valid_permlink` (≤256 chars), with legacy-compatible public messages.

## 3. Negative-limit clamping

Negative user-provided limits reached SQL as `LIMIT -N`, which **Postgres treats as UNBOUNDED** — a full cache-table scan per request. All cursor query limits are clamped non-positive → 0 (empty result) via `apierrors.ClampLimit`.

## New package `internal/apierrors`
PublicError type + validators/clamp, table-driven tests.

## Verified live (real server binary + curl)
- bad account name → `data: 'invalid account char in ...'` (public, validated pre-DB)
- feed sort → `data: 'feed sort is not implemented'`
- method not found → data forwarded
- negative limit → empty result (no table scan)
- internal paths expose no error detail

## Validation
`go build` / `go vet` / `go test ./...` all green.
