### PR TITLE
feat(api): implement remaining API stubs (PR#10, KR6)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,6 +51,14 @@ func main() {
 	// builders (stats.hide/blacklists). Empty URL = disabled list.
 	steem.SetSharedMutes(steem.NewMutes(cfg.Steem.MutedAccountsURL))
 
+	// Steemd client: backs condenser_api.get_transaction (block lookups).
+	// Client creation is lazy (no connection is made until called), so the
+	// server still starts when steemd is unreachable.
+	steemd, err := steem.New(&cfg.Steem)
+	if err != nil {
+		logger.Fatal("Failed to create steemd client", zap.Error(err))
+	}
+
 	// Initialize database
 	database, err := db.New(&cfg.Database, cfg.Logging.Level)
 	if err != nil {
@@ -97,7 +105,7 @@ func main() {
 	router.Use(middleware.MetricsMiddleware())
 
 	// Setup API routes
-	apiRouter := api.NewRouter(database, redisCache)
+	apiRouter := api.NewRouter(database, redisCache, steemd, cfg.Indexer.RecommendCommunities)
 	apiRouter.SetupRoutes(router)
 
 	// Create HTTP server with timeouts to prevent slow-client goroutine leaks

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -383,7 +383,9 @@ Get state for a path (compatibility method).
 **Parameters:**
 - `path` (string, required): State path
 
-**Returns:** State object (varies by path)
+**Returns:** Not implemented — returns an explicit error. The full get_state
+router only served the retired condenser frontend; use the bridge/condenser
+discussion methods instead.
 
 #### condenser_api.get_account_votes
 

--- a/internal/api/bridge/post.go
+++ b/internal/api/bridge/post.go
@@ -3,7 +3,9 @@ package bridge
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/steemit/hivemind/internal/apierrors"
+	"github.com/steemit/hivemind/internal/models"
 
 	"github.com/gin-gonic/gin"
 
@@ -35,6 +37,7 @@ func (p *PostAPI) GetPost(ctx *gin.Context, params json.RawMessage) (interface{}
 	author, _ := pMap["author"].(string)
 	permlink, _ := pMap["permlink"].(string)
 	observer, _ := pMap["observer"].(string)
+	_ = observer // TODO: observer context (user-post state)
 
 	telemetry.AddSpanAttributes(span, map[string]string{
 		"author":   author,
@@ -57,17 +60,22 @@ func (p *PostAPI) GetPost(ctx *gin.Context, params json.RawMessage) (interface{}
 
 	// Record metrics
 	telemetry.PostsFetched.WithLabelValues("bridge.get_post").Inc()
+
+	// Build the full bridge post object (cache-backed, mirrors legacy
+	// get_post -> load_posts).
+	loader := objects.NewPostLoader(p.repo.DB())
+	posts, err := loader.LoadPostsBridge(ctx.Request.Context(), []int64{post.ID}, 0)
+	if err != nil {
+		telemetry.RecordSpanError(span, err)
+		return nil, err
+	}
+	if len(posts) == 0 {
+		// Post exists in hive_posts but has no cache row yet.
+		return nil, nil
+	}
+
 	telemetry.SetSpanSuccess(span)
-
-	// TODO: Build full post object with cached data and observer context
-	_ = observer
-
-	return map[string]interface{}{
-		"id":       post.ID,
-		"author":   post.Author,
-		"permlink": post.Permlink,
-		"category": post.Category,
-	}, nil
+	return posts[0], nil
 }
 
 // NormalizePost handles bridge.normalize_post
@@ -171,13 +179,23 @@ func (p *PostAPI) GetPostHeader(ctx *gin.Context, params json.RawMessage) (inter
 		return nil, nil
 	}
 
+	// Title comes from the cached post data (hive_posts_cache).
+	var cacheRow models.PostCache
+	title := ""
+	if err := p.repo.DB().WithContext(ctx.Request.Context()).
+		Where("post_id = ?", post.ID).
+		Select("title").
+		First(&cacheRow).Error; err == nil {
+		title = cacheRow.Title
+	}
+
 	telemetry.PostsFetched.WithLabelValues("bridge.get_post_header").Inc()
 	telemetry.SetSpanSuccess(span)
 
 	return map[string]interface{}{
 		"author":   post.Author,
 		"permlink": post.Permlink,
-		"title":    "", // TODO: Get from cached post data
+		"title":    title,
 		"category": post.Category,
 		"depth":    post.Depth,
 	}, nil

--- a/internal/api/bridge/ranked.go
+++ b/internal/api/bridge/ranked.go
@@ -1,36 +1,57 @@
 package bridge
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/steemit/hivemind/internal/apierrors"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/steemit/hivemind/internal/api/condenser"
+	"github.com/steemit/hivemind/internal/api/objects"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/internal/cache"
 	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
+	"github.com/steemit/hivemind/pkg/telemetry"
 )
 
 // RankedAPI provides ranked posts API methods
 type RankedAPI struct {
-	repo   *db.Repository
-	cursor *condenser.Cursor
-	cache  *cache.Cache
+	repo                 *db.Repository
+	cursor               *condenser.Cursor
+	cache                *cache.Cache
+	loader               *objects.PostLoader
+	recommendCommunities []string
 }
 
-// NewRankedAPI creates a new ranked API
-func NewRankedAPI(repo *db.Repository, database *db.DB, redisCache *cache.Cache) *RankedAPI {
+// NewRankedAPI creates a new ranked API. recommendCommunities is the
+// comma-separated HIVE_RECOMMEND_COMMUNITIES config used by
+// bridge.get_trending_topics.
+func NewRankedAPI(repo *db.Repository, database *db.DB, redisCache *cache.Cache, recommendCommunities string) *RankedAPI {
+	var recommended []string
+	for _, name := range strings.Split(recommendCommunities, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			recommended = append(recommended, name)
+		}
+	}
 	return &RankedAPI{
-		repo:   repo,
-		cursor: condenser.NewCursor(database.DB),
-		cache:  redisCache,
+		repo:                 repo,
+		cursor:               condenser.NewCursor(database.DB),
+		cache:                redisCache,
+		loader:               objects.NewPostLoader(database.DB),
+		recommendCommunities: recommended,
 	}
 }
 
 // GetRankedPosts handles bridge.get_ranked_posts
+// Query posts, sorted by the given method; returns full bridge post objects.
 func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
+	_, span := telemetry.StartSpanWithName(ctx.Request.Context(), "bridge.get_ranked_posts")
+	defer span.End()
+
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
 		return nil, apierrors.PublicError("invalid parameters format")
@@ -61,7 +82,7 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 		tag = t
 	}
 	observer, _ := pMap["observer"].(string)
-	_ = observer // TODO: Use for personalized content
+	_ = observer // TODO: observer context (tag='my' subscribed communities)
 
 	// Generate cache key using hash to shorten long keys
 	cacheKeyParts := []string{
@@ -90,7 +111,7 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 		"promoted":        "promoted",
 		"payout":          "payout",
 		"payout_comments": "payout_comments",
-		"muted":           "muted", // Special case
+		"muted":           "muted",
 	}
 
 	querySort, ok := sortMap[sort]
@@ -101,15 +122,22 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 	// Get post IDs
 	ids, err := r.cursor.GetPostIDsByQuery(ctx.Request.Context(), querySort, startAuthor, startPermlink, limit, tag)
 	if err != nil {
+		telemetry.RecordSpanError(span, err)
 		return nil, err
 	}
 
-	// TODO: Load full post objects
-	result := make([]interface{}, len(ids))
-	for i, id := range ids {
-		result[i] = map[string]interface{}{
-			"id": id,
-		}
+	// Filter article-blocked posts (legacy hide_pids_by_ids).
+	ids, err = r.filterHidden(ctx.Request.Context(), ids)
+	if err != nil {
+		telemetry.RecordSpanError(span, err)
+		return nil, err
+	}
+
+	// Load full bridge post objects
+	result, err := r.loader.LoadPostsBridge(ctx.Request.Context(), ids, 0)
+	if err != nil {
+		telemetry.RecordSpanError(span, err)
+		return nil, err
 	}
 
 	// Cache result
@@ -122,7 +150,30 @@ func (r *RankedAPI) GetRankedPosts(ctx *gin.Context, params json.RawMessage) (in
 		}
 	}
 
+	telemetry.SetSpanSuccess(span)
 	return result, nil
+}
+
+// filterHidden removes article-blocked posts from an id list.
+func (r *RankedAPI) filterHidden(ctx context.Context, ids []int64) ([]int64, error) {
+	if len(ids) == 0 {
+		return ids, nil
+	}
+	statusRepo := db.NewPostStatusRepository(r.repo)
+	hidden, err := statusRepo.GetHiddenPostIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	if len(hidden) == 0 {
+		return ids, nil
+	}
+	filtered := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if !hidden[id] {
+			filtered = append(filtered, id)
+		}
+	}
+	return filtered, nil
 }
 
 // getCacheTTL returns cache TTL based on sort type
@@ -132,7 +183,7 @@ func (r *RankedAPI) getCacheTTL(sort string) time.Duration {
 		return 3 * time.Second
 	case "trending", "hot":
 		return 300 * time.Second
-	case "payout":
+	case "payout", "payout_comments":
 		return 30 * time.Second
 	case "muted":
 		return 600 * time.Second
@@ -142,7 +193,11 @@ func (r *RankedAPI) getCacheTTL(sort string) time.Duration {
 }
 
 // GetAccountPosts handles bridge.get_account_posts
+// Posts for an account: blog, feed, posts, comments, replies, or payout.
 func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
+	_, span := telemetry.StartSpanWithName(ctx.Request.Context(), "bridge.get_account_posts")
+	defer span.End()
+
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
 		return nil, apierrors.PublicError("invalid parameters format")
@@ -152,10 +207,21 @@ func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (i
 	if sort == "" {
 		return nil, apierrors.PublicError("missing required parameter: sort")
 	}
+	validSorts := map[string]bool{
+		"blog": true, "feed": true, "posts": true,
+		"comments": true, "replies": true, "payout": true,
+	}
+	if !validSorts[sort] {
+		return nil, apierrors.Publicf("invalid sort type: %s", sort)
+	}
 
 	account, _ := pMap["account"].(string)
 	if account == "" {
 		return nil, apierrors.PublicError("missing required parameter: account")
+	}
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
 	}
 
 	startAuthor := ""
@@ -174,59 +240,124 @@ func (r *RankedAPI) GetAccountPosts(ctx *gin.Context, params json.RawMessage) (i
 		}
 	}
 
-	// Handle different sort types
+	// Author-blocked accounts (list_type=3) return nothing.
+	statusRepo := db.NewPostStatusRepository(r.repo)
+	authorHidden, err := statusRepo.IsAuthorHidden(ctx.Request.Context(), account)
+	if err != nil {
+		telemetry.RecordSpanError(span, err)
+		return nil, err
+	}
+	if authorHidden {
+		return []map[string]interface{}{}, nil
+	}
+
+	// For self-authored sorts, the seek post must belong to the account;
+	// without a seek permlink the account itself is the start (legacy
+	// normalizes start to (account, None) for these sorts).
+	if startPermlink == "" {
+		switch sort {
+		case "posts", "comments", "replies", "payout":
+			startAuthor = account
+		}
+	}
+	if (sort == "posts" || sort == "comments") && startAuthor != account {
+		return nil, apierrors.PublicError("account must match start author")
+	}
+
+	var result []map[string]interface{}
+	reqCtx := ctx.Request.Context()
 	switch sort {
 	case "blog":
-		// Get from feed cache
-		ids, err := r.cursor.GetPostIDsByBlog(ctx.Request.Context(), account, startAuthor, startPermlink, limit)
+		ids, err := r.cursor.GetPostIDsByBlog(reqCtx, account, startAuthor, startPermlink, limit)
 		if err != nil {
 			return nil, err
 		}
-		result := make([]interface{}, len(ids))
-		for i, id := range ids {
-			result[i] = map[string]interface{}{"id": id}
+		ids, err = r.filterHidden(reqCtx, ids)
+		if err != nil {
+			return nil, err
 		}
-		return result, nil
+		result, err = r.loader.LoadPostsBridge(reqCtx, ids, 0)
+		if err != nil {
+			return nil, err
+		}
+		// Reblogs surface the account itself as reblogger.
+		for _, post := range result {
+			if author, _ := post["author"].(string); author != account {
+				post["reblogged_by"] = []string{account}
+			}
+		}
 	case "feed":
-		// TODO: Implement personalized feed (follows join feed_cache, see
-		// legacy pids_by_feed_with_reblog). Must NOT delegate to self with
-		// unchanged params — that is infinite recursion (stack overflow).
-		return nil, apierrors.PublicError("feed sort is not implemented")
-	case "posts":
-		// Author's posts only (no reblogs)
-		// TODO: Implement
-		return []interface{}{}, nil
-	case "comments":
-		// Author's comments
-		// TODO: Implement
-		return []interface{}{}, nil
-	case "replies":
-		// Replies to author's posts
-		// TODO: Implement
-		return []interface{}{}, nil
-	case "payout":
-		// Posts sorted by payout
-		ids, err := r.cursor.GetPostIDsByQuery(ctx.Request.Context(), "payout", startAuthor, startPermlink, limit, "")
+		entries, err := r.cursor.GetPostIDsByFeedWithReblog(reqCtx, account, startAuthor, startPermlink, limit)
 		if err != nil {
 			return nil, err
 		}
-		result := make([]interface{}, len(ids))
-		for i, id := range ids {
-			result[i] = map[string]interface{}{"id": id}
+		ids := make([]int64, 0, len(entries))
+		rebloggers := make(map[int64]string, len(entries))
+		for _, e := range entries {
+			ids = append(ids, e.PostID)
+			rebloggers[e.PostID] = e.Accounts
 		}
-		return result, nil
-	default:
-		return nil, apierrors.Publicf("invalid sort type: %s", sort)
+		result, err = r.loader.LoadPostsReblogsBridge(reqCtx, ids, rebloggers, 0)
+		if err != nil {
+			return nil, err
+		}
+	case "posts":
+		ids, err := r.cursor.GetPostIDsByAccountPosts(reqCtx, account, startPermlink, limit)
+		if err != nil {
+			return nil, err
+		}
+		ids, err = r.filterHidden(reqCtx, ids)
+		if err != nil {
+			return nil, err
+		}
+		result, err = r.loader.LoadPostsBridge(reqCtx, ids, 0)
+		if err != nil {
+			return nil, err
+		}
+	case "comments":
+		ids, err := r.cursor.GetPostIDsByAccountComments(reqCtx, account, startPermlink, limit)
+		if err != nil {
+			return nil, err
+		}
+		result, err = r.loader.LoadPostsBridge(reqCtx, ids, 0)
+		if err != nil {
+			return nil, err
+		}
+	case "replies":
+		ids, err := r.cursor.GetPostIDsByRepliesToAccount(reqCtx, startAuthor, startPermlink, limit)
+		if err != nil {
+			return nil, err
+		}
+		result, err = r.loader.LoadPostsBridge(reqCtx, ids, 0)
+		if err != nil {
+			return nil, err
+		}
+	case "payout":
+		ids, err := r.cursor.GetPostIDsByPayout(reqCtx, account, startAuthor, startPermlink, limit)
+		if err != nil {
+			return nil, err
+		}
+		ids, err = r.filterHidden(reqCtx, ids)
+		if err != nil {
+			return nil, err
+		}
+		result, err = r.loader.LoadPostsBridge(reqCtx, ids, 0)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	telemetry.SetSpanSuccess(span)
+	return result, nil
 }
 
 // GetTrendingTopics handles bridge.get_trending_topics
+// Top communities first, then a fixed set of common tags.
 func (r *RankedAPI) GetTrendingTopics(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
-		return nil, apierrors.PublicError("invalid parameters format")
+		pMap = map[string]interface{}{}
 	}
-
 	limit := 10
 	if l, ok := pMap["limit"].(float64); ok {
 		limit = int(l)
@@ -235,7 +366,57 @@ func (r *RankedAPI) GetTrendingTopics(ctx *gin.Context, params json.RawMessage) 
 		}
 	}
 
-	// TODO: Query trending topics from tags
-	// For now, return empty result
-	return []interface{}{}, nil
+	out := []interface{}{}
+
+	// Recommended communities (config), then by rank.
+	var rows []models.Community
+	query := r.repo.DB().WithContext(ctx.Request.Context()).
+		Model(&models.Community{}).
+		Select("name", "title").
+		Where("rank > 0").
+		Order("rank")
+	if len(r.recommendCommunities) > 0 {
+		var recommended []models.Community
+		if err := r.repo.DB().WithContext(ctx.Request.Context()).
+			Model(&models.Community{}).
+			Select("name", "title").
+			Where("name IN ?", r.recommendCommunities).
+			Find(&recommended).Error; err != nil {
+			return nil, err
+		}
+		for _, comm := range recommended {
+			title := comm.Title
+			if title == "" {
+				title = comm.Name
+			}
+			out = append(out, []interface{}{comm.Name, title})
+		}
+		if len(out) < limit {
+			query = query.Where("name NOT IN ?", r.recommendCommunities).Limit(limit - len(out))
+		} else {
+			query = query.Limit(0)
+		}
+	} else {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, comm := range rows {
+		title := comm.Title
+		if title == "" {
+			title = comm.Name
+		}
+		out = append(out, []interface{}{comm.Name, title})
+	}
+
+	// Fill the remainder with common tags (mirrors legacy fixed list).
+	for _, tag := range []string{"photography", "travel", "gaming", "crypto", "newsteem", "music", "food"} {
+		if len(out) >= limit {
+			break
+		}
+		out = append(out, []interface{}{tag, "#" + tag})
+	}
+
+	return out, nil
 }

--- a/internal/api/bridge/ranked_test.go
+++ b/internal/api/bridge/ranked_test.go
@@ -2,60 +2,299 @@ package bridge
 
 import (
 	"encoding/json"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
 )
 
-// TestGetAccountPosts_FeedSortNoRecursion is a regression test for the
-// 2026-08-16 security audit finding: `case "feed"` used to delegate to
-// GetAccountPosts with unchanged params — infinite recursion, stack overflow,
-// uncatchable by gin.Recovery(), crashing the whole process on a single
-// unauthenticated request.
+// TestGetAccountPosts_ParamValidationBeforeDB verifies that parameter
+// validation happens before any DB access: a zero-value RankedAPI (nil
+// repo/cursor) must return a clean PublicError, not panic.
 //
-// The feed branch must return an explicit error BEFORE any DB access, so this
-// test uses a zero-value RankedAPI (nil cursor/repo) and asserts we get an
-// error, not a crash.
-func TestGetAccountPosts_FeedSortNoRecursion(t *testing.T) {
+// This is the evolved form of the 2026-08-16 security-audit regression guard
+// (feed sort used to delegate to itself with unchanged params — infinite
+// recursion / stack overflow). All sorts are now implemented inline in the
+// switch, so self-recursion is structurally impossible; the remaining guard
+// is that bad input fails fast.
+func TestGetAccountPosts_ParamValidationBeforeDB(t *testing.T) {
 	r := &RankedAPI{}
 	gin.SetMode(gin.TestMode)
-	ctx := &gin.Context{}
 
-	params, _ := json.Marshal(map[string]interface{}{
-		"sort":    "feed",
-		"account": "alice",
-	})
-
-	result, err := r.GetAccountPosts(ctx, params)
-
-	if err == nil {
-		t.Fatalf("feed sort must return an explicit not-implemented error, got result=%v", result)
+	cases := []struct {
+		name   string
+		params map[string]interface{}
+		errMsg string
+	}{
+		{
+			name:   "invalid sort",
+			params: map[string]interface{}{"sort": "bogus", "account": "alice"},
+			errMsg: "invalid sort type",
+		},
+		{
+			name:   "missing sort",
+			params: map[string]interface{}{"account": "alice"},
+			errMsg: "missing required parameter: sort",
+		},
+		{
+			name:   "missing account",
+			params: map[string]interface{}{"sort": "feed"},
+			errMsg: "missing required parameter: account",
+		},
+		{
+			name:   "invalid account name",
+			params: map[string]interface{}{"sort": "feed", "account": "ALICE"},
+			errMsg: "invalid account",
+		},
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("error should mention 'not implemented', got: %v", err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(w)
+			ctx.Request = httptest.NewRequest("POST", "/", nil)
+
+			params, _ := json.Marshal(tc.params)
+			result, err := r.GetAccountPosts(ctx, params)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got result=%v", tc.errMsg, result)
+			}
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error should contain %q, got: %v", tc.errMsg, err)
+			}
+		})
 	}
 }
 
-// TestGetAccountPosts_UnimplementedSorts verifies the other stub sorts return
-// explicit empty results (their documented placeholder shape) rather than
-// delegating anywhere.
-func TestGetAccountPosts_UnimplementedSorts(t *testing.T) {
-	r := &RankedAPI{}
-	gin.SetMode(gin.TestMode)
-	ctx := &gin.Context{}
+// TestGetAccountPosts_Sorts exercises every account sort against a real
+// Postgres schema: blog (with reblog attribution), feed (follows join with
+// string_agg rebloggers), posts, comments, replies, and payout (temp table),
+// plus the author-blocked short-circuit.
+//
+// Requires a live Postgres; skipped when HIVE_TEST_DATABASE_URL is not set:
+//
+//	HIVE_TEST_DATABASE_URL=postgresql://test:test@localhost:5433/hive go test -run TestGetAccountPosts_Sorts ./internal/api/bridge/...
+func TestGetAccountPosts_Sorts(t *testing.T) {
+	if os.Getenv("HIVE_TEST_DATABASE_URL") == "" {
+		t.Skip("HIVE_TEST_DATABASE_URL not set; skipping account posts sorts test")
+	}
+	dbURL := newTestDB(t)
 
-	for _, sort := range []string{"posts", "comments", "replies"} {
-		params, _ := json.Marshal(map[string]interface{}{
-			"sort":    sort,
-			"account": "alice",
-		})
-		result, err := r.GetAccountPosts(ctx, params)
+	resetSchema(t, dbURL)
+	if err := db.RunMigrations(dbURL, 0); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open gorm: %v", err)
+	}
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatalf("raw db: %v", err)
+	}
+	defer sqlDB.Close()
+
+	seedAccountPosts(t, gdb)
+
+	repo := db.NewRepository(gdb)
+	wrapped := &db.DB{DB: gdb}
+	api := NewRankedAPI(repo, wrapped, nil, "hive-123456")
+
+	call := func(sort string) []map[string]interface{} {
+		t.Helper()
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("POST", "/", nil)
+		params, _ := json.Marshal(map[string]interface{}{"sort": sort, "account": "alice", "limit": 10})
+		result, err := api.GetAccountPosts(ctx, params)
 		if err != nil {
-			t.Errorf("sort %q returned error %v (expected empty placeholder)", sort, err)
+			t.Fatalf("sort %q: %v", sort, err)
 		}
-		if result == nil {
-			t.Errorf("sort %q returned nil (expected empty slice)", sort)
+		posts, ok := result.([]map[string]interface{})
+		if !ok {
+			t.Fatalf("sort %q: expected []map, got %T", sort, result)
 		}
+		return posts
+	}
+
+	permlinks := func(posts []map[string]interface{}) []string {
+		out := make([]string, 0, len(posts))
+		for _, p := range posts {
+			out = append(out, p["permlink"].(string))
+		}
+		return out
+	}
+	expectList := func(sort string, got []string, want []string) {
+		t.Helper()
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("sort %q: expected %v, got %v", sort, want, got)
+		}
+	}
+
+	// blog: own post + reblogged post, reblog attributed to alice.
+	blog := call("blog")
+	expectList("blog", permlinks(blog), []string{"post-b", "post-a"})
+	for _, p := range blog {
+		if p["permlink"] == "post-b" {
+			rby, ok := p["reblogged_by"].([]string)
+			if !ok || len(rby) != 1 || rby[0] != "alice" {
+				t.Errorf("blog: post-b should be reblogged_by [alice], got %v", p["reblogged_by"])
+			}
+		}
+	}
+
+	// feed: posts from follows (bob's post-b), reblogger = bob himself is
+	// excluded from reblogged_by (he's the author).
+	feed := call("feed")
+	expectList("feed", permlinks(feed), []string{"post-b"})
+	if len(feed) > 0 {
+		if _, has := feed[0]["reblogged_by"]; has {
+			t.Errorf("feed: author reblogger should be excluded, got %v", feed[0]["reblogged_by"])
+		}
+	}
+
+	// posts: alice's own top-level posts only.
+	expectList("posts", permlinks(call("posts")), []string{"post-a"})
+
+	// comments: alice's comments only.
+	expectList("comments", permlinks(call("comments")), []string{"comment-x"})
+
+	// replies: replies to alice's posts (carol's reply-y).
+	expectList("replies", permlinks(call("replies")), []string{"reply-y"})
+
+	// payout: reads hive_posts_cache_temp; legacy does not filter by depth
+	// here (author's unpaid posts AND comments, payout descending).
+	expectList("payout", permlinks(call("payout")), []string{"post-a", "comment-x"})
+
+	// author-blocked account returns empty.
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("POST", "/", nil)
+	params, _ := json.Marshal(map[string]interface{}{"sort": "posts", "account": "mallory", "limit": 10})
+	result, err := api.GetAccountPosts(ctx, params)
+	if err != nil {
+		t.Fatalf("blocked author: %v", err)
+	}
+	if blocked, ok := result.([]map[string]interface{}); !ok || len(blocked) != 0 {
+		t.Errorf("blocked author should return empty, got %v", result)
+	}
+}
+
+// seedAccountPosts builds the fixture for TestGetAccountPosts_Sorts:
+//
+//	alice: post-a (depth 0), comment-x (depth 1 on bob's post)
+//	bob:   post-b (depth 0), reblogged by alice into her blog
+//	carol: reply-y (depth 1 on alice's post-a)
+//	mallory: blocked author (hive_posts_status list_type 3)
+//	alice follows bob; feed_cache rows for alice (post-a, post-b) and bob
+//	(post-b); hive_posts_cache + hive_posts_cache_temp rows for payouts.
+func seedAccountPosts(t *testing.T, gdb *gorm.DB) {
+	t.Helper()
+	now := time.Now().UTC()
+
+	for _, name := range []string{"alice", "bob", "carol", "mallory"} {
+		if err := gdb.Create(&models.Account{Name: name, CreatedAt: now}).Error; err != nil {
+			t.Fatalf("seed account %s: %v", name, err)
+		}
+	}
+
+	mk := func(id int64, parent int64, author, permlink string, depth int16) models.Post {
+		p := models.Post{
+			Author:    author,
+			Permlink:  permlink,
+			Category:  "test",
+			CreatedAt: now,
+			Depth:     depth,
+		}
+		p.ID = id
+		if parent != 0 {
+			p.ParentID.Valid = true
+			p.ParentID.Int64 = parent
+		}
+		return p
+	}
+	posts := []models.Post{
+		mk(1, 0, "alice", "post-a", 0),
+		mk(2, 0, "bob", "post-b", 0),
+		mk(3, 2, "alice", "comment-x", 1),
+		mk(4, 1, "carol", "reply-y", 1),
+		mk(5, 0, "mallory", "post-m", 0),
+	}
+	for i := range posts {
+		if err := gdb.Create(&posts[i]).Error; err != nil {
+			t.Fatalf("seed post %d: %v", posts[i].ID, err)
+		}
+	}
+
+	// hive_accounts ids for follows/feed_cache.
+	var alice, bob models.Account
+	if err := gdb.Where("name = ?", "alice").First(&alice).Error; err != nil {
+		t.Fatalf("load alice: %v", err)
+	}
+	if err := gdb.Where("name = ?", "bob").First(&bob).Error; err != nil {
+		t.Fatalf("load bob: %v", err)
+	}
+
+	// alice follows bob (state 1 = blog follow).
+	if err := gdb.Create(&models.Follow{FollowerID: alice.ID, FollowingID: bob.ID, State: 1, CreatedAt: now}).Error; err != nil {
+		t.Fatalf("seed follow: %v", err)
+	}
+
+	// Blog: alice's feed_cache has her own post and bob's reblogged post;
+	// bob's feed_cache has his own post (which surfaces in alice's feed).
+	feeds := []models.FeedCache{
+		{PostID: 1, AccountID: alice.ID, CreatedAt: now.Add(-2 * time.Hour)},
+		{PostID: 2, AccountID: alice.ID, CreatedAt: now.Add(-1 * time.Hour)},
+		{PostID: 2, AccountID: bob.ID, CreatedAt: now.Add(-3 * time.Hour)},
+	}
+	for i := range feeds {
+		if err := gdb.Create(&feeds[i]).Error; err != nil {
+			t.Fatalf("seed feed: %v", err)
+		}
+	}
+
+	// Cache rows (bridge loader requires them) + temp table for payout sort.
+	cache := func(postID int64, author, permlink string, payout float64) models.PostCache {
+		return models.PostCache{
+			PostID: postID, Author: author, Permlink: permlink, Category: "test",
+			Title: "t-" + permlink, CreatedAt: now, PayoutAt: now.Add(24 * time.Hour),
+			UpdatedAt: now, Payout: payout,
+		}
+	}
+	caches := []models.PostCache{
+		cache(1, "alice", "post-a", 9),
+		cache(2, "bob", "post-b", 5),
+		cache(3, "alice", "comment-x", 1),
+		cache(4, "carol", "reply-y", 1),
+		cache(5, "mallory", "post-m", 1),
+	}
+	for i := range caches {
+		if err := gdb.Create(&caches[i]).Error; err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+		temp := models.PostCacheTemp{
+			PostID: caches[i].PostID, Author: caches[i].Author, Permlink: caches[i].Permlink,
+			Category: caches[i].Category, Title: caches[i].Title, CreatedAt: now,
+			PayoutAt: caches[i].PayoutAt, UpdatedAt: now, Payout: caches[i].Payout,
+		}
+		if err := gdb.Create(&temp).Error; err != nil {
+			t.Fatalf("seed cache temp: %v", err)
+		}
+	}
+
+	// mallory is author-blocked (list_type 3).
+	if err := gdb.Create(&models.PostStatus{Author: "mallory", ListType: models.PostStatusUserBlock, CreatedAt: now}).Error; err != nil {
+		t.Fatalf("seed post status: %v", err)
 	}
 }

--- a/internal/api/condenser/blog.go
+++ b/internal/api/condenser/blog.go
@@ -2,92 +2,139 @@ package condenser
 
 import (
 	"encoding/json"
-	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/steemit/hivemind/internal/api/objects"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/internal/db"
 )
 
 // BlogAPI provides blog-related API methods
 type BlogAPI struct {
-	repo   *db.Repository
-	cursor *Cursor
+	repo       *db.Repository
+	cursor     *Cursor
+	postLoader *objects.PostLoader
 }
 
 // NewBlogAPI creates a new blog API
 func NewBlogAPI(repo *db.Repository, database *db.DB) *BlogAPI {
 	return &BlogAPI{
-		repo:   repo,
-		cursor: NewCursor(database.DB),
+		repo:       repo,
+		cursor:     NewCursor(database.DB),
+		postLoader: objects.NewPostLoader(database.DB),
 	}
 }
 
 // GetBlog handles condenser_api.get_blog
+// Posts for an author's blog (w/ reblogs), paged by entry index. Equivalent
+// to get_discussions_by_blog, but uses offset-based pagination.
 func (b *BlogAPI) GetBlog(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p []interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, err
-	}
-
-	if len(p) < 1 {
-		return nil, apierrors.PublicError("missing required parameter: account")
-	}
-
-	account, _ := p[0].(string)
-	startEntryID := int64(0)
-	if len(p) > 1 {
-		if id, ok := p[1].(float64); ok {
-			startEntryID = int64(id)
-		}
-	}
-	limit := 20
-	if len(p) > 2 {
-		if l, ok := p[2].(float64); ok {
-			limit = int(l)
-			if limit > 100 {
-				limit = 100
-			}
-		}
-	}
-
-	// Get account ID
-	accountRepo := db.NewAccountRepository(b.repo)
-	acc, err := accountRepo.GetByName(ctx.Request.Context(), account)
-	if err != nil {
-		return nil, err
-	}
-	if acc == nil {
-		return []interface{}{}, nil
-	}
-
-	// Query feed cache with entry_id pagination
-	// TODO: Implement entry_id based pagination
-	// For now, use simple limit
-	ids, err := b.cursor.GetPostIDsByBlog(ctx.Request.Context(), account, "", "", limit)
+	arr, err := parseListParams(params, 3, 2)
 	if err != nil {
 		return nil, err
 	}
 
-	// Build blog entries
-	result := make([]interface{}, len(ids))
-	for i, id := range ids {
-		result[i] = map[string]interface{}{
-			"blog":     account,
-			"entry_id": startEntryID + int64(i),
-			"comment": map[string]interface{}{
-				"id": id,
-			},
-		}
+	account := paramString(arr, 0)
+	account, err = apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
 	}
 
-	return result, nil
+	startIndex := paramInt(arr, 1)
+	limit := paramInt(arr, 2)
+	// legacy _get_blog: an omitted limit returns entries 0..start_index.
+	if limit == 0 {
+		limit = startIndex + 1
+	}
+	if limit, err = apierrors.ValidLimit(limit, 500); err != nil {
+		return nil, err
+	}
+	if startIndex < 0 {
+		return nil, apierrors.Publicf("invalid start entry_id: %d", startIndex)
+	}
+
+	entries, err := b.loadBlogEntries(ctx, account, startIndex, limit)
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 // GetBlogEntries handles condenser_api.get_blog_entries
+// Interface identical to get_blog, but returns minimalistic post references:
+// {blog, entry_id, author, permlink, reblog_on}.
 func (b *BlogAPI) GetBlogEntries(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// TODO: Implement (legacy returns a LIGHTWEIGHT shape: {blog, entry_id,
-	// author, permlink, reblog_on} — delegating to GetBlog would return full
-	// post objects, which is the wrong response shape).
-	return nil, apierrors.PublicError("not implemented")
+	arr, err := parseListParams(params, 3, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	account := paramString(arr, 0)
+	account, err = apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
+	}
+
+	startIndex := paramInt(arr, 1)
+	limit := paramInt(arr, 2)
+	if limit == 0 {
+		limit = startIndex + 1
+	}
+	if limit, err = apierrors.ValidLimit(limit, 500); err != nil {
+		return nil, err
+	}
+	if startIndex < 0 {
+		return nil, apierrors.Publicf("invalid start entry_id: %d", startIndex)
+	}
+
+	fullEntries, err := b.loadBlogEntries(ctx, account, startIndex, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace the full comment object with author/permlink references.
+	out := make([]map[string]interface{}, 0, len(fullEntries))
+	for _, entry := range fullEntries {
+		post, _ := entry["comment"].(map[string]interface{})
+		entry["author"] = post["author"]
+		entry["permlink"] = post["permlink"]
+		delete(entry, "comment")
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// loadBlogEntries pages the blog by entry index and builds the legacy entry
+// list: {blog, entry_id, comment, reblogged_on}, entry_id descending.
+func (b *BlogAPI) loadBlogEntries(ctx *gin.Context, account string, startIndex, limit int) ([]map[string]interface{}, error) {
+	resolvedStart, ids, err := b.cursor.GetPostIDsByBlogByIndex(ctx.Request.Context(), account, startIndex, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	posts, err := b.postLoader.LoadPosts(ctx.Request.Context(), ids, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]interface{}, 0, len(posts))
+	idx := resolvedStart
+	for _, post := range posts {
+		author, _ := post["author"].(string)
+		created, _ := post["created"].(string)
+		reblog := author != account
+		reblogOn := "1970-01-01T00:00:00"
+		if reblog {
+			reblogOn = created
+		}
+		out = append(out, map[string]interface{}{
+			"blog":         account,
+			"entry_id":     idx,
+			"comment":      post,
+			"reblogged_on": reblogOn,
+		})
+		idx--
+	}
+	return out, nil
 }

--- a/internal/api/condenser/condenser_test.go
+++ b/internal/api/condenser/condenser_test.go
@@ -1,0 +1,328 @@
+package condenser
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
+)
+
+func TestParseQueryParams(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    string
+		assert func(t *testing.T, p map[string]interface{}, err error)
+	}{
+		{
+			name: "object form",
+			raw:  `{"tag": "steem", "limit": 1}`,
+			assert: func(t *testing.T, p map[string]interface{}, err error) {
+				if err != nil || p["tag"] != "steem" || p["limit"] != float64(1) {
+					t.Fatalf("got %v err=%v", p, err)
+				}
+			},
+		},
+		{
+			name: "nested query form (nested_query_compat)",
+			raw:  `[{"tag": "steem", "limit": 1}]`,
+			assert: func(t *testing.T, p map[string]interface{}, err error) {
+				if err != nil || p["tag"] != "steem" || p["limit"] != float64(1) {
+					t.Fatalf("got %v err=%v", p, err)
+				}
+			},
+		},
+		{
+			name: "positional form",
+			raw:  `["steem", "alice", "plink", 5]`,
+			assert: func(t *testing.T, p map[string]interface{}, err error) {
+				if err != nil || p["tag"] != "steem" || p["start_author"] != "alice" ||
+					p["start_permlink"] != "plink" || p["limit"] != float64(5) {
+					t.Fatalf("got %v err=%v", p, err)
+				}
+			},
+		},
+		{
+			name: "positional form with object start",
+			raw:  `["steem", "alice"]`,
+			assert: func(t *testing.T, p map[string]interface{}, err error) {
+				if err != nil || p["tag"] != "steem" || p["start_author"] != "alice" {
+					t.Fatalf("got %v err=%v", p, err)
+				}
+			},
+		},
+		{
+			name: "empty array",
+			raw:  `[]`,
+			assert: func(t *testing.T, p map[string]interface{}, err error) {
+				if err != nil || len(p) != 0 {
+					t.Fatalf("got %v err=%v", p, err)
+				}
+			},
+		},
+		{
+			name: "invalid form",
+			raw:  `"steem"`,
+			assert: func(t *testing.T, p map[string]interface{}, err error) {
+				if err == nil {
+					t.Fatalf("expected error, got %v", p)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := parseQueryParams(json.RawMessage(tc.raw), "tag", "start_author", "start_permlink", "limit")
+			tc.assert(t, p, err)
+		})
+	}
+}
+
+func TestParseListParams(t *testing.T) {
+	if _, err := parseListParams(json.RawMessage(`["a", "b"]`), 3, 2); err != nil {
+		t.Errorf("min window: %v", err)
+	}
+	if _, err := parseListParams(json.RawMessage(`["a", "b", "c"]`), 3, 2); err != nil {
+		t.Errorf("exact len: %v", err)
+	}
+	if _, err := parseListParams(json.RawMessage(`["a"]`), 3, 2); err == nil {
+		t.Errorf("below min: expected error")
+	}
+	if _, err := parseListParams(json.RawMessage(`["a","b","c","d"]`), 3, 2); err == nil {
+		t.Errorf("above max: expected error")
+	}
+	if _, err := parseListParams(json.RawMessage(`{"a":1}`), 3, 3); err == nil {
+		t.Errorf("object form: expected error")
+	}
+}
+
+// newTestDB creates a dedicated database (hive_condenser_test) for this package.
+func newTestDB(t *testing.T) string {
+	t.Helper()
+	baseURL := os.Getenv("HIVE_TEST_DATABASE_URL")
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse db url: %v", err)
+	}
+	u.Path = "/postgres"
+	maintDSN := u.String()
+
+	raw, err := sql.Open("pgx", maintDSN)
+	if err != nil {
+		t.Fatalf("open maintenance conn: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`DROP DATABASE IF EXISTS hive_condenser_test;`); err != nil {
+		t.Fatalf("drop test db: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE DATABASE hive_condenser_test;`); err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	u.Path = "/hive_condenser_test"
+	return u.String()
+}
+
+// call invokes a condenser API handler with raw JSON params.
+func call(t *testing.T, handler func(*gin.Context, json.RawMessage) (interface{}, error), raw string) interface{} {
+	t.Helper()
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("POST", "/", nil)
+	result, err := handler(ctx, json.RawMessage(raw))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return result
+}
+
+// TestMiscBlogTagsMethods covers the condenser misc/blog/tags methods
+// against a real Postgres schema. Requires HIVE_TEST_DATABASE_URL.
+func TestMiscBlogTagsMethods(t *testing.T) {
+	if os.Getenv("HIVE_TEST_DATABASE_URL") == "" {
+		t.Skip("HIVE_TEST_DATABASE_URL not set; skipping condenser integration test")
+	}
+	dbURL := newTestDB(t)
+	raw, err := sql.Open("pgx", dbURL)
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	if _, err := raw.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	raw.Close()
+	if err := db.RunMigrations(dbURL, 0); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open gorm: %v", err)
+	}
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatalf("raw db: %v", err)
+	}
+	defer sqlDB.Close()
+
+	seedCondenserFixture(t, gdb)
+
+	gin.SetMode(gin.TestMode)
+	repo := db.NewRepository(gdb)
+	wrapped := &db.DB{DB: gdb}
+	misc := NewMiscAPI(repo, wrapped, nil)
+	blog := NewBlogAPI(repo, wrapped)
+	tags := NewTagsAPI(repo, wrapped)
+
+	// get_discussions_by_comments: alice's comments only.
+	comments := call(t, misc.GetDiscussionsByComments,
+		`{"start_author": "alice", "limit": 10}`).([]map[string]interface{})
+	if len(comments) != 1 || comments[0]["permlink"] != "comment-x" {
+		t.Fatalf("by_comments: got %v", comments)
+	}
+	// Nested query form must parse identically (parameter shape unification).
+	commentsNested := call(t, misc.GetDiscussionsByComments,
+		`[{"start_author": "alice", "limit": 10}]`).([]map[string]interface{})
+	if len(commentsNested) != len(comments) {
+		t.Fatalf("by_comments nested form: got %d, want %d", len(commentsNested), len(comments))
+	}
+
+	// get_replies_by_last_update: replies to alice's posts.
+	replies := call(t, misc.GetRepliesByLastUpdate,
+		`["alice", "", 10]`).([]map[string]interface{})
+	if len(replies) != 1 || replies[0]["permlink"] != "reply-y" {
+		t.Fatalf("replies_by_last_update: got %v", replies)
+	}
+
+	// get_discussions_by_author_before_date: alice's posts, no reblogs.
+	before := call(t, misc.GetDiscussionsByAuthorBeforeDate,
+		`["alice", "", "", 10]`).([]map[string]interface{})
+	if len(before) != 1 || before[0]["permlink"] != "post-a" {
+		t.Fatalf("by_author_before_date: got %v", before)
+	}
+
+	// get_blog: entry_id pagination; entry ids descend from the start index.
+	blogFull := call(t, blog.GetBlog, `["alice", -0, 0]`).([]map[string]interface{})
+	// With limit 0 -> limit = start_index+1 = 1: only the newest entry.
+	if len(blogFull) != 1 {
+		t.Fatalf("get_blog: expected 1 entry, got %v", blogFull)
+	}
+	if blogFull[0]["entry_id"] != int(1) || blogFull[0]["blog"] != "alice" {
+		t.Fatalf("get_blog entry: got %v", blogFull[0])
+	}
+	if c, ok := blogFull[0]["comment"].(map[string]interface{}); !ok || c["permlink"] != "post-b" {
+		t.Fatalf("get_blog comment: got %v", blogFull[0]["comment"])
+	}
+
+	blogAll := call(t, blog.GetBlog, `["alice", 0, 2]`).([]map[string]interface{})
+	if len(blogAll) != 2 {
+		t.Fatalf("get_blog all: expected 2 entries, got %v", blogAll)
+	}
+	if blogAll[0]["entry_id"] != int(1) || blogAll[1]["entry_id"] != int(0) {
+		t.Fatalf("get_blog entry ids descending: got %v", blogAll)
+	}
+	if blogAll[0]["reblogged_on"] == "1970-01-01T00:00:00" {
+		t.Errorf("get_blog: reblogged entry should carry a timestamp")
+	}
+
+	// get_blog_entries: lightweight shape.
+	entries := call(t, blog.GetBlogEntries, `["alice", 0, 2]`).([]map[string]interface{})
+	if len(entries) != 2 {
+		t.Fatalf("get_blog_entries: got %v", entries)
+	}
+	if _, has := entries[0]["comment"]; has {
+		t.Errorf("get_blog_entries: comment key should be stripped")
+	}
+	if entries[0]["author"] != "bob" || entries[0]["permlink"] != "post-b" {
+		t.Fatalf("get_blog_entries[0]: got %v", entries[0])
+	}
+
+	// get_trending_tags: aggregate over pending posts.
+	tt := call(t, tags.GetTrendingTags, `["", 10]`).([]map[string]interface{})
+	if len(tt) != 1 || tt[0]["name"] != "test" {
+		t.Fatalf("get_trending_tags: got %v", tt)
+	}
+	if tt[0]["top_posts"] != int64(2) || tt[0]["comments"] != int64(2) {
+		t.Fatalf("get_trending_tags counts: got %v", tt[0])
+	}
+
+	// get_state stays an explicit refusal.
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("POST", "/", nil)
+	if _, err := misc.GetState(ctx, json.RawMessage(`["trending"]`)); err == nil {
+		t.Errorf("get_state must return an explicit not-implemented error")
+	}
+}
+
+// seedCondenserFixture builds alice/bob/carol accounts, posts (1 root +
+// reblog for the blog, 1 comment, 1 reply), cache rows and feed entries.
+func seedCondenserFixture(t *testing.T, gdb *gorm.DB) {
+	t.Helper()
+	now := time.Now().UTC()
+
+	for _, name := range []string{"alice", "bob", "carol"} {
+		if err := gdb.Create(&models.Account{Name: name, CreatedAt: now}).Error; err != nil {
+			t.Fatalf("seed account %s: %v", name, err)
+		}
+	}
+	var aliceID int64
+	if err := gdb.Raw("SELECT id FROM hive_accounts WHERE name = 'alice'").Scan(&aliceID).Error; err != nil {
+		t.Fatalf("load alice: %v", err)
+	}
+
+	mk := func(id int64, parent int64, author, permlink string, depth int16) models.Post {
+		p := models.Post{Author: author, Permlink: permlink, Category: "test", CreatedAt: now, Depth: depth}
+		p.ID = id
+		if parent != 0 {
+			p.ParentID.Valid = true
+			p.ParentID.Int64 = parent
+		}
+		return p
+	}
+	posts := []models.Post{
+		mk(1, 0, "alice", "post-a", 0),
+		mk(2, 0, "bob", "post-b", 0),
+		mk(3, 2, "alice", "comment-x", 1),
+		mk(4, 1, "carol", "reply-y", 1),
+	}
+	for i := range posts {
+		if err := gdb.Create(&posts[i]).Error; err != nil {
+			t.Fatalf("seed post: %v", err)
+		}
+	}
+
+	caches := []models.PostCache{
+		{PostID: 1, Author: "alice", Permlink: "post-a", Category: "test", Title: "A", CreatedAt: now, PayoutAt: now, UpdatedAt: now, Depth: 0, Payout: 3},
+		{PostID: 2, Author: "bob", Permlink: "post-b", Category: "test", Title: "B", CreatedAt: now, PayoutAt: now, UpdatedAt: now, Depth: 0, Payout: 5},
+		{PostID: 3, Author: "alice", Permlink: "comment-x", Category: "test", Title: "C", CreatedAt: now, PayoutAt: now, UpdatedAt: now, Depth: 1, Payout: 1},
+		{PostID: 4, Author: "carol", Permlink: "reply-y", Category: "test", Title: "D", CreatedAt: now, PayoutAt: now, UpdatedAt: now, Depth: 1, Payout: 1},
+	}
+	for i := range caches {
+		if err := gdb.Create(&caches[i]).Error; err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+	}
+
+	feeds := []models.FeedCache{
+		{PostID: 1, AccountID: aliceID, CreatedAt: now.Add(-2 * time.Hour)},
+		{PostID: 2, AccountID: aliceID, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+	for i := range feeds {
+		if err := gdb.Create(&feeds[i]).Error; err != nil {
+			t.Fatalf("seed feed: %v", err)
+		}
+	}
+}

--- a/internal/api/condenser/cursor.go
+++ b/internal/api/condenser/cursor.go
@@ -2,8 +2,10 @@ package condenser
 
 import (
 	"context"
-	"github.com/steemit/hivemind/internal/apierrors"
 	"strings"
+	"time"
+
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"gorm.io/gorm"
 
@@ -48,6 +50,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 		"promoted":        true,
 		"payout":          true,
 		"payout_comments": true,
+		"muted":           true,
 	}
 	if !validSorts[sort] {
 		return nil, apierrors.Publicf("invalid sort type: %s", sort)
@@ -77,6 +80,10 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 			Order("payout DESC")
 	case "payout_comments":
 		query = query.Where("is_paidout = ? AND depth > ?", false, 0).
+			Order("payout DESC")
+	case "muted":
+		// Grayed posts with pending payout, by payout (bridge muted sort).
+		query = query.Where("is_paidout = ? AND is_grayed = ? AND payout > ?", false, true, 0).
 			Order("payout DESC")
 	}
 
@@ -118,7 +125,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 			if err := c.db.WithContext(ctx).Where("post_id = ?", startID).Select("sc_hot").First(&cache).Error; err == nil {
 				startValue = cache.SCHot
 			}
-		case "created", "payout", "payout_comments":
+		case "created", "payout", "payout_comments", "muted":
 			startValue = startID
 		}
 
@@ -128,7 +135,7 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 				query = query.Where("sc_trend <= ?", startValue)
 			case "hot":
 				query = query.Where("sc_hot <= ?", startValue)
-			case "created", "payout", "payout_comments":
+			case "created", "payout", "payout_comments", "muted":
 				query = query.Where("hive_posts_cache.post_id <= ?", startValue)
 			}
 		}
@@ -153,6 +160,465 @@ func (c *Cursor) GetPostIDsByQuery(ctx context.Context, sort, startAuthor, start
 	}
 
 	return ids, nil
+}
+
+// FeedEntry pairs a post ID with the CSV of account names that surfaced it
+// in a feed (string_agg over hive_feed_cache, mirrors legacy
+// pids_by_feed_with_reblog).
+type FeedEntry struct {
+	PostID   int64  `gorm:"column:post_id"`
+	Accounts string `gorm:"column:accounts"`
+}
+
+// getAccountIDByName resolves an account name to its hive_accounts.id.
+// Returns 0 when the account does not exist.
+func (c *Cursor) getAccountIDByName(ctx context.Context, name string) (int64, error) {
+	var acc models.Account
+	err := c.db.WithContext(ctx).
+		Where("name = ?", name).
+		Select("id").
+		First(&acc).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return acc.ID, nil
+}
+
+// GetPostIDsByAccountPosts returns top-level posts (depth = 0) authored by
+// `account`. Mirrors legacy bridge cursor.pids_by_posts.
+func (c *Cursor) GetPostIDsByAccountPosts(ctx context.Context, account, startPermlink string, limit int) ([]int64, error) {
+	query := c.db.WithContext(ctx).
+		Model(&models.Post{}).
+		Select("id").
+		Where("author = ? AND is_deleted = ? AND depth = ?", account, false, 0)
+
+	if startPermlink != "" {
+		startID, err := c.GetPostIDByAuthorPermlink(ctx, account, startPermlink)
+		if err != nil {
+			return nil, err
+		}
+		if startID == 0 {
+			return []int64{}, nil
+		}
+		query = query.Where("id <= ?", startID)
+	}
+
+	var results []struct {
+		ID int64 `gorm:"column:id"`
+	}
+	// `depth` in ORDER BY is a no-op, but forces an ix3 index scan (see #189)
+	if err := query.Order("id DESC, depth").Limit(apierrors.ClampLimit(limit)).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids, nil
+}
+
+// GetPostIDsByAccountComments returns comments (depth > 0) authored by
+// `account`. Mirrors legacy cursor.pids_by_account_comments /
+// bridge cursor.pids_by_comments (identical SQL).
+func (c *Cursor) GetPostIDsByAccountComments(ctx context.Context, account, startPermlink string, limit int) ([]int64, error) {
+	query := c.db.WithContext(ctx).
+		Model(&models.Post{}).
+		Select("id").
+		Where("author = ? AND is_deleted = ? AND depth > ?", account, false, 0)
+
+	if startPermlink != "" {
+		startID, err := c.GetPostIDByAuthorPermlink(ctx, account, startPermlink)
+		if err != nil {
+			return nil, err
+		}
+		if startID == 0 {
+			return []int64{}, nil
+		}
+		query = query.Where("id <= ?", startID)
+	}
+
+	var results []struct {
+		ID int64 `gorm:"column:id"`
+	}
+	if err := query.Order("id DESC, depth").Limit(apierrors.ClampLimit(limit)).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids, nil
+}
+
+// GetPostIDsByBlogWithoutReblog returns an author's blog posts without
+// reblogs. Mirrors legacy cursor.pids_by_blog_without_reblog. before_date is
+// ignored, matching legacy (broken in steemd as well).
+func (c *Cursor) GetPostIDsByBlogWithoutReblog(ctx context.Context, account, startPermlink string, limit int) ([]int64, error) {
+	query := c.db.WithContext(ctx).
+		Model(&models.Post{}).
+		Select("id").
+		Where("author = ? AND is_deleted = ? AND depth = ?", account, false, 0)
+
+	if startPermlink != "" {
+		startID, err := c.GetPostIDByAuthorPermlink(ctx, account, startPermlink)
+		if err != nil {
+			return nil, err
+		}
+		if startID == 0 {
+			return []int64{}, nil
+		}
+		query = query.Where("id <= ?", startID)
+	}
+
+	var results []struct {
+		ID int64 `gorm:"column:id"`
+	}
+	if err := query.Order("id DESC").Limit(apierrors.ClampLimit(limit)).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids, nil
+}
+
+// GetPostIDsByRepliesToAccount returns replies made to any of `startAuthor`'s
+// posts. First page: startAuthor = the account being replied to. Subsequent
+// pages: pass the last loaded reply's author/permlink. Mirrors legacy
+// cursor.pids_by_replies_to_account.
+func (c *Cursor) GetPostIDsByRepliesToAccount(ctx context.Context, startAuthor, startPermlink string, limit int) ([]int64, error) {
+	parentAccount := startAuthor
+	seek := ""
+	args := []interface{}{parentAccount}
+
+	if startPermlink != "" {
+		var row struct {
+			ParentAuthor string `gorm:"column:parent_author"`
+			ID           int64  `gorm:"column:id"`
+		}
+		err := c.db.WithContext(ctx).Raw(
+			`SELECT parent.author AS parent_author, child.id
+			   FROM hive_posts child
+			   JOIN hive_posts parent ON child.parent_id = parent.id
+			  WHERE child.author = ? AND child.permlink = ?`,
+			startAuthor, startPermlink,
+		).Scan(&row).Error
+		if err != nil {
+			return nil, err
+		}
+		if row.ID == 0 {
+			return []int64{}, nil
+		}
+		parentAccount = row.ParentAuthor
+		seek = "AND id <= ?"
+		args = append(args, row.ID)
+	}
+
+	sql := `
+	   SELECT id FROM hive_posts
+	    WHERE parent_id IN (SELECT id FROM hive_posts
+	                         WHERE author = ?
+	                           AND is_deleted = '0'
+	                      ORDER BY id DESC
+	                         LIMIT 10000) ` + seek + `
+	      AND is_deleted = '0'
+	 ORDER BY id DESC
+	    LIMIT ?`
+	args = append(args, apierrors.ClampLimit(limit))
+
+	var results []struct {
+		ID int64 `gorm:"column:id"`
+	}
+	if err := c.db.WithContext(ctx).Raw(sql, args...).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids, nil
+}
+
+// GetPostIDsByPayout returns an author's posts sorted by pending payout,
+// reading the hot-data window from hive_posts_cache_temp (mirrors legacy
+// bridge cursor.pids_by_payout which reads CacheRouter.TEMP_TABLE).
+func (c *Cursor) GetPostIDsByPayout(ctx context.Context, account, startAuthor, startPermlink string, limit int) ([]int64, error) {
+	seek := ""
+	var args []interface{}
+
+	if startPermlink != "" {
+		startID, err := c.GetPostIDByAuthorPermlink(ctx, startAuthor, startPermlink)
+		if err != nil {
+			return nil, err
+		}
+		if startID == 0 {
+			return []int64{}, nil
+		}
+		seek = `AND (payout < (SELECT payout FROM hive_posts_cache_temp WHERE post_id = ?)
+                  OR (payout = (SELECT payout FROM hive_posts_cache_temp WHERE post_id = ?) AND post_id > ?))`
+		args = append(args, startID, startID, startID)
+	}
+
+	sql := `
+	    SELECT post_id
+	      FROM hive_posts_cache_temp
+	     WHERE author = ?
+	       AND is_paidout = '0' ` + seek + `
+	 ORDER BY payout DESC, post_id
+	    LIMIT ?`
+	args = append(args, account, apierrors.ClampLimit(limit))
+
+	var results []struct {
+		PostID int64 `gorm:"column:post_id"`
+	}
+	if err := c.db.WithContext(ctx).Raw(sql, args...).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.PostID
+	}
+	return ids, nil
+}
+
+// GetPostIDsByFeedWithReblog returns the personalized feed for `account`
+// (posts + reblogs from accounts they follow), with the reblogger names
+// aggregated per post. Mirrors legacy bridge cursor.pids_by_feed_with_reblog:
+// single GROUP BY query over hive_feed_cache joined with hive_follows.
+func (c *Cursor) GetPostIDsByFeedWithReblog(ctx context.Context, account, startAuthor, startPermlink string, limit int) ([]FeedEntry, error) {
+	accountID, err := c.getAccountIDByName(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	if accountID == 0 {
+		return []FeedEntry{}, nil
+	}
+
+	seek := ""
+	var args []interface{}
+
+	if startPermlink != "" {
+		startID, err := c.GetPostIDByAuthorPermlink(ctx, startAuthor, startPermlink)
+		if err != nil {
+			return nil, err
+		}
+		if startID == 0 {
+			return []FeedEntry{}, nil
+		}
+
+		// Pre-fetch the seek timestamp to avoid a nested subquery in HAVING.
+		var startCreatedAt struct {
+			CreatedAt time.Time `gorm:"column:created_at"`
+		}
+		err = c.db.WithContext(ctx).Raw(
+			`SELECT MIN(fc.created_at) AS created_at
+			   FROM hive_feed_cache fc
+			  INNER JOIN hive_follows hf
+			      ON fc.account_id = hf.following
+			     AND hf.follower = ?
+			     AND hf.state IN (1, 3)
+			  WHERE fc.post_id = ?`,
+			accountID, startID,
+		).Scan(&startCreatedAt).Error
+		if err != nil {
+			return nil, err
+		}
+		if !startCreatedAt.CreatedAt.IsZero() {
+			seek = "HAVING MIN(hive_feed_cache.created_at) <= ?"
+			args = append(args, startCreatedAt.CreatedAt)
+		}
+	}
+
+	cutoff := time.Now().AddDate(0, -1, 0)
+	sql := `
+	    SELECT post_id, string_agg(name, ',') AS accounts
+	      FROM hive_feed_cache
+	     INNER JOIN hive_follows
+	         ON account_id = hive_follows.following
+	        AND hive_follows.follower = ?
+	        AND hive_follows.state IN (1, 3)
+	     INNER JOIN hive_accounts ON hive_follows.following = hive_accounts.id
+	     WHERE hive_feed_cache.created_at > ? ` + seek + `
+	  GROUP BY post_id
+	 ORDER BY MIN(hive_feed_cache.created_at) DESC
+	    LIMIT ?`
+	args = append(args, accountID, cutoff, apierrors.ClampLimit(limit))
+
+	var results []FeedEntry
+	if err := c.db.WithContext(ctx).Raw(sql, args...).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// GetPostIDsByBlogByIndex pages an author's blog (w/ reblogs) by entry index.
+// (acct, -1) or (acct, 0) resolves to the newest entry; the returned slice is
+// ordered newest-first like legacy pids_by_blog_by_index.
+func (c *Cursor) GetPostIDsByBlogByIndex(ctx context.Context, account string, startIndex, limit int) (int, []int64, error) {
+	accountID, err := c.getAccountIDByName(ctx, account)
+	if err != nil {
+		return 0, nil, err
+	}
+	if accountID == 0 {
+		return 0, []int64{}, nil
+	}
+
+	if startIndex == -1 || startIndex == 0 {
+		var count int64
+		if err := c.db.WithContext(ctx).Model(&models.FeedCache{}).
+			Where("account_id = ?", accountID).
+			Count(&count).Error; err != nil {
+			return 0, nil, err
+		}
+		startIndex = int(count) - 1
+		if startIndex < 0 {
+			return 0, []int64{}, nil
+		}
+	}
+
+	offset := startIndex - limit + 1
+	if offset < 0 {
+		return 0, nil, apierrors.Publicf("start_index and limit combination is invalid (%d, %d)", startIndex, limit)
+	}
+
+	var results []struct {
+		PostID int64 `gorm:"column:post_id"`
+	}
+	if err := c.db.WithContext(ctx).
+		Model(&models.FeedCache{}).
+		Select("post_id").
+		Where("account_id = ?", accountID).
+		Order("created_at").
+		Offset(offset).
+		Limit(apierrors.ClampLimit(limit)).
+		Scan(&results).Error; err != nil {
+		return 0, nil, err
+	}
+
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.PostID
+	}
+	// Reverse so the result is newest-first.
+	for i, j := 0, len(ids)-1; i < j; i, j = i+1, j-1 {
+		ids[i], ids[j] = ids[j], ids[i]
+	}
+	return startIndex, ids, nil
+}
+
+// GetFollowerNames returns names of accounts following `account`
+// (created_at DESC cursor, mirroring legacy condenser cursor.get_followers).
+func (c *Cursor) GetFollowerNames(ctx context.Context, account, start string, limit int) ([]string, error) {
+	accountID, err := c.getAccountIDByName(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	if accountID == 0 {
+		return nil, apierrors.Publicf("account not found: `%s`", account)
+	}
+
+	sql := `
+	    SELECT ha.name
+	      FROM hive_follows hf
+	     INNER JOIN hive_accounts ha ON hf.follower = ha.id
+	     WHERE hf.following = ?
+	       AND hf.state IN (1, 3)`
+	args := []interface{}{accountID}
+
+	if start != "" {
+		startID, err := c.getAccountIDByName(ctx, start)
+		if err != nil {
+			return nil, err
+		}
+		if startID != 0 {
+			sql += ` AND hf.created_at <= (
+			             SELECT created_at FROM hive_follows
+			              WHERE following = ? AND follower = ?)`
+			args = append(args, accountID, startID)
+		}
+	}
+	sql += " ORDER BY hf.created_at DESC LIMIT ?"
+	args = append(args, apierrors.ClampLimit(limit))
+
+	var names []string
+	if err := c.db.WithContext(ctx).Raw(sql, args...).Scan(&names).Error; err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+// GetFollowingNames returns names of accounts followed by `account`
+// (created_at DESC cursor, mirroring legacy condenser cursor.get_following).
+func (c *Cursor) GetFollowingNames(ctx context.Context, account, start string, limit int) ([]string, error) {
+	accountID, err := c.getAccountIDByName(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	if accountID == 0 {
+		return nil, apierrors.Publicf("account not found: `%s`", account)
+	}
+
+	sql := `
+	    SELECT ha.name
+	      FROM hive_follows hf
+	     INNER JOIN hive_accounts ha ON hf.following = ha.id
+	     WHERE hf.follower = ?
+	       AND hf.state IN (1, 3)`
+	args := []interface{}{accountID}
+
+	if start != "" {
+		startID, err := c.getAccountIDByName(ctx, start)
+		if err != nil {
+			return nil, err
+		}
+		if startID != 0 {
+			sql += ` AND hf.created_at <= (
+			             SELECT created_at FROM hive_follows
+			              WHERE follower = ? AND following = ?)`
+			args = append(args, accountID, startID)
+		}
+	}
+	sql += " ORDER BY hf.created_at DESC LIMIT ?"
+	args = append(args, apierrors.ClampLimit(limit))
+
+	var names []string
+	if err := c.db.WithContext(ctx).Raw(sql, args...).Scan(&names).Error; err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+// GetMutedNames returns names of all accounts muted by `account`
+// (state includes the ignore bit). Mirrors legacy hive_api list_all_muted.
+func (c *Cursor) GetMutedNames(ctx context.Context, account string) ([]string, error) {
+	accountID, err := c.getAccountIDByName(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	if accountID == 0 {
+		return nil, apierrors.Publicf("account not found: `%s`", account)
+	}
+
+	sql := `
+	    SELECT a.name
+	      FROM hive_follows f
+	      JOIN hive_accounts a ON f.following = a.id
+	     WHERE f.follower = ? AND f.state IN (2, 3)`
+
+	var names []string
+	if err := c.db.WithContext(ctx).Raw(sql, accountID).Scan(&names).Error; err != nil {
+		return nil, err
+	}
+	return names, nil
 }
 
 // GetPostIDsByBlog gets post IDs for an account's blog

--- a/internal/api/condenser/discussions.go
+++ b/internal/api/condenser/discussions.go
@@ -2,11 +2,12 @@ package condenser
 
 import (
 	"encoding/json"
-	"github.com/steemit/hivemind/internal/apierrors"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/steemit/hivemind/internal/api/objects"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/internal/db"
 )
 
@@ -48,42 +49,16 @@ func (d *DiscussionsAPI) GetDiscussionsByPromoted(ctx *gin.Context, params json.
 
 // getDiscussionsBySort is a helper that handles all sort-based discussion queries
 func (d *DiscussionsAPI) getDiscussionsBySort(ctx *gin.Context, sort string, params json.RawMessage) (interface{}, error) {
-	// Parse parameters
-	var p map[string]interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
-		// Try array format
-		var arr []interface{}
-		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, apierrors.PublicError("invalid parameters format")
-		}
-		// Convert array to map (legacy format)
-		p = make(map[string]interface{})
-		if len(arr) > 0 {
-			if m, ok := arr[0].(map[string]interface{}); ok {
-				p = m
-			}
-		}
+	// Parse parameters (object, nested-query, or positional form).
+	p, err := parseQueryParams(params, "tag", "start_author", "start_permlink", "limit", "truncate_body")
+	if err != nil {
+		return nil, err
 	}
 
-	startAuthor := ""
-	if sa, ok := p["start_author"].(string); ok {
-		startAuthor = sa
-	}
-	startPermlink := ""
-	if sp, ok := p["start_permlink"].(string); ok {
-		startPermlink = sp
-	}
-	limit := 20
-	if l, ok := p["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 100 {
-			limit = 100
-		}
-	}
-	tag := ""
-	if t, ok := p["tag"].(string); ok {
-		tag = t
-	}
+	startAuthor, _ := p["start_author"].(string)
+	startPermlink, _ := p["start_permlink"].(string)
+	limit := limitFromQuery(p, 20, 100)
+	tag, _ := p["tag"].(string)
 
 	// Get post IDs
 	ids, err := d.cursor.GetPostIDsByQuery(ctx.Request.Context(), sort, startAuthor, startPermlink, limit, tag)
@@ -92,10 +67,7 @@ func (d *DiscussionsAPI) getDiscussionsBySort(ctx *gin.Context, sort string, par
 	}
 
 	// Load full post objects
-	truncateBody := 0
-	if tb, ok := p["truncate_body"].(float64); ok {
-		truncateBody = int(tb)
-	}
+	truncateBody := truncateBodyFromQuery(p)
 
 	posts, err := d.postLoader.LoadPosts(ctx.Request.Context(), ids, truncateBody)
 	if err != nil {
@@ -107,38 +79,15 @@ func (d *DiscussionsAPI) getDiscussionsBySort(ctx *gin.Context, sort string, par
 
 // GetDiscussionsByBlog handles condenser_api.get_discussions_by_blog
 func (d *DiscussionsAPI) GetDiscussionsByBlog(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p map[string]interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
-		var arr []interface{}
-		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, apierrors.PublicError("invalid parameters format")
-		}
-		if len(arr) > 0 {
-			if m, ok := arr[0].(map[string]interface{}); ok {
-				p = m
-			}
-		}
+	p, err := parseQueryParams(params, "tag", "start_author", "start_permlink", "limit", "truncate_body")
+	if err != nil {
+		return nil, err
 	}
 
-	tag := ""
-	if t, ok := p["tag"].(string); ok {
-		tag = t
-	}
-	startAuthor := ""
-	if sa, ok := p["start_author"].(string); ok {
-		startAuthor = sa
-	}
-	startPermlink := ""
-	if sp, ok := p["start_permlink"].(string); ok {
-		startPermlink = sp
-	}
-	limit := 20
-	if l, ok := p["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 100 {
-			limit = 100
-		}
-	}
+	tag, _ := p["tag"].(string)
+	startAuthor, _ := p["start_author"].(string)
+	startPermlink, _ := p["start_permlink"].(string)
+	limit := limitFromQuery(p, 20, 100)
 
 	// tag parameter is actually the account name for blog queries
 	account := tag
@@ -153,10 +102,7 @@ func (d *DiscussionsAPI) GetDiscussionsByBlog(ctx *gin.Context, params json.RawM
 	}
 
 	// Load full post objects
-	truncateBody := 0
-	if tb, ok := p["truncate_body"].(float64); ok {
-		truncateBody = int(tb)
-	}
+	truncateBody := truncateBodyFromQuery(p)
 
 	posts, err := d.postLoader.LoadPosts(ctx.Request.Context(), ids, truncateBody)
 	if err != nil {
@@ -167,9 +113,78 @@ func (d *DiscussionsAPI) GetDiscussionsByBlog(ctx *gin.Context, params json.RawM
 }
 
 // GetDiscussionsByFeed handles condenser_api.get_discussions_by_feed
+// The account's personalized feed: posts + resteems from everyone they follow,
+// with reblogged_by attribution (mirrors legacy pids_by_feed_with_reblog +
+// load_posts_reblogs).
 func (d *DiscussionsAPI) GetDiscussionsByFeed(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// TODO: Implement personalized feed (follows join feed_cache, see legacy
-	// pids_by_feed_with_reblog). Must NOT silently return blog results —
-	// feed and blog are different result sets.
-	return nil, apierrors.PublicError("not implemented")
+	p, err := parseQueryParams(params, "tag", "start_author", "start_permlink", "limit", "truncate_body")
+	if err != nil {
+		return nil, err
+	}
+
+	tag, _ := p["tag"].(string)
+	if tag == "" {
+		return nil, apierrors.PublicError("`tag` cannot be blank")
+	}
+	account, err := apierrors.ValidAccount(tag, false)
+	if err != nil {
+		return nil, err
+	}
+	startAuthor, _ := p["start_author"].(string)
+	if startAuthor != "" {
+		startAuthor, err = apierrors.ValidAccount(startAuthor, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	startPermlink, _ := p["start_permlink"].(string)
+	if startPermlink != "" {
+		if _, err := apierrors.ValidPermlink(startPermlink, false); err != nil {
+			return nil, err
+		}
+	}
+	limit := limitFromQuery(p, 20, 100)
+	truncateBody := truncateBodyFromQuery(p)
+
+	entries, err := d.cursor.GetPostIDsByFeedWithReblog(ctx.Request.Context(), account, startAuthor, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, 0, len(entries))
+	rebloggers := make(map[int64]string, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.PostID)
+		rebloggers[e.PostID] = e.Accounts
+	}
+
+	posts, err := d.postLoader.LoadPosts(ctx.Request.Context(), ids, truncateBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge reblogged_by (comma-joined names, author excluded) — mirrors
+	// legacy condenser load_posts_reblogs.
+	for _, post := range posts {
+		pid, _ := post["id"].(int64)
+		csv, ok := rebloggers[pid]
+		if !ok || csv == "" {
+			continue
+		}
+		author, _ := post["author"].(string)
+		seen := make(map[string]bool)
+		rby := make([]interface{}, 0, 4)
+		for _, name := range strings.Split(csv, ",") {
+			if name == "" || name == author || seen[name] {
+				continue
+			}
+			seen[name] = true
+			rby = append(rby, name)
+		}
+		if len(rby) > 0 {
+			post["reblogged_by"] = rby
+		}
+	}
+
+	return posts, nil
 }

--- a/internal/api/condenser/misc.go
+++ b/internal/api/condenser/misc.go
@@ -2,260 +2,269 @@ package condenser
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/steemit/hivemind/internal/api/objects"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
+	"github.com/steemit/hivemind/internal/steem"
 )
 
 // MiscAPI provides miscellaneous API methods
 type MiscAPI struct {
-	repo   *db.Repository
-	cursor *Cursor
+	repo       *db.Repository
+	cursor     *Cursor
+	postLoader *objects.PostLoader
+	steemd     *steem.Client
 }
 
-// NewMiscAPI creates a new misc API
-func NewMiscAPI(repo *db.Repository, database *db.DB) *MiscAPI {
+// NewMiscAPI creates a new misc API. The steemd client is optional and only
+// required by get_transaction; nil disables that method.
+func NewMiscAPI(repo *db.Repository, database *db.DB, steemd *steem.Client) *MiscAPI {
 	return &MiscAPI{
-		repo:   repo,
-		cursor: NewCursor(database.DB),
+		repo:       repo,
+		cursor:     NewCursor(database.DB),
+		postLoader: objects.NewPostLoader(database.DB),
+		steemd:     steemd,
 	}
 }
 
 // GetDiscussionsByComments handles condenser_api.get_discussions_by_comments
+// Comments made by start_author.
 func (m *MiscAPI) GetDiscussionsByComments(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p map[string]interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
-		var arr []interface{}
-		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, apierrors.PublicError("invalid parameters format")
-		}
-		if len(arr) > 0 {
-			if mp, ok := arr[0].(map[string]interface{}); ok {
-				p = mp
-			}
-		}
+	p, err := parseQueryParams(params, "start_author", "start_permlink", "limit", "truncate_body")
+	if err != nil {
+		return nil, err
 	}
 
-	startAuthor := ""
-	if sa, ok := p["start_author"].(string); ok {
-		startAuthor = sa
-	}
+	startAuthor, _ := p["start_author"].(string)
 	if startAuthor == "" {
-		return nil, fmt.Errorf("start_author cannot be blank")
+		return nil, apierrors.PublicError("`start_author` cannot be blank")
+	}
+	startAuthor, err = apierrors.ValidAccount(startAuthor, false)
+	if err != nil {
+		return nil, err
 	}
 
-	startPermlink := ""
-	if sp, ok := p["start_permlink"].(string); ok {
-		startPermlink = sp
-	}
-	limit := 20
-	if l, ok := p["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 100 {
-			limit = 100
+	startPermlink, _ := p["start_permlink"].(string)
+	if startPermlink != "" {
+		if _, err := apierrors.ValidPermlink(startPermlink, false); err != nil {
+			return nil, err
 		}
 	}
+	limit := limitFromQuery(p, 20, 100)
+	truncateBody := truncateBodyFromQuery(p)
 
-	// Query comments by author
-	// TODO: Implement pids_by_account_comments query
-	// For now, return empty result
-	_ = startPermlink // TODO: Use for pagination
-	return []interface{}{}, nil
+	ids, err := m.cursor.GetPostIDsByAccountComments(ctx.Request.Context(), startAuthor, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+	return m.postLoader.LoadPosts(ctx.Request.Context(), ids, truncateBody)
 }
 
 // GetRepliesByLastUpdate handles condenser_api.get_replies_by_last_update
+// All replies made to any of start_author's posts.
 func (m *MiscAPI) GetRepliesByLastUpdate(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p []interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
+	p, err := parseQueryParams(params, "start_author", "start_permlink", "limit")
+	if err != nil {
 		return nil, err
 	}
 
-	if len(p) < 1 {
-		return nil, apierrors.PublicError("missing required parameter: start_author")
+	startAuthor, _ := p["start_author"].(string)
+	if startAuthor == "" {
+		return nil, apierrors.PublicError("`start_author` cannot be blank")
+	}
+	startAuthor, err = apierrors.ValidAccount(startAuthor, false)
+	if err != nil {
+		return nil, err
 	}
 
-	startAuthor, _ := p[0].(string)
-	startPermlink := ""
-	if len(p) > 1 {
-		startPermlink, _ = p[1].(string)
-	}
-	limit := 20
-	if len(p) > 2 {
-		if l, ok := p[2].(float64); ok {
-			limit = int(l)
-			if limit > 100 {
-				limit = 100
-			}
+	startPermlink, _ := p["start_permlink"].(string)
+	if startPermlink != "" {
+		if _, err := apierrors.ValidPermlink(startPermlink, false); err != nil {
+			return nil, err
 		}
 	}
+	limit := limitFromQuery(p, 20, 100)
 
-	// TODO: Query replies to author's posts
-	_ = startAuthor
-	_ = startPermlink
-	_ = limit
-
-	return []interface{}{}, nil
+	ids, err := m.cursor.GetPostIDsByRepliesToAccount(ctx.Request.Context(), startAuthor, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+	return m.postLoader.LoadPosts(ctx.Request.Context(), ids, 0)
 }
 
-// GetDiscussionsByAuthorBeforeDate handles condenser_api.get_discussions_by_author_before_date
+// GetDiscussionsByAuthorBeforeDate handles
+// condenser_api.get_discussions_by_author_before_date. Returns the author's
+// blog posts without reblogs. before_date is ignored, matching legacy
+// (broken/ignored in steemd as well).
 func (m *MiscAPI) GetDiscussionsByAuthorBeforeDate(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p []interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
+	p, err := parseQueryParams(params, "author", "start_permlink", "before_date", "limit")
+	if err != nil {
 		return nil, err
 	}
 
-	if len(p) < 1 {
-		return nil, apierrors.PublicError("missing required parameter: author")
+	author, _ := p["author"].(string)
+	if author == "" {
+		return nil, apierrors.PublicError("`author` cannot be blank")
+	}
+	author, err = apierrors.ValidAccount(author, false)
+	if err != nil {
+		return nil, err
 	}
 
-	author, _ := p[0].(string)
-	startPermlink := ""
-	if len(p) > 1 {
-		startPermlink, _ = p[1].(string)
-	}
-	beforeDate := ""
-	if len(p) > 2 {
-		beforeDate, _ = p[2].(string)
-	}
-	limit := 10
-	if len(p) > 3 {
-		if l, ok := p[3].(float64); ok {
-			limit = int(l)
-			if limit > 100 {
-				limit = 100
-			}
+	startPermlink, _ := p["start_permlink"].(string)
+	if startPermlink != "" {
+		if _, err := apierrors.ValidPermlink(startPermlink, false); err != nil {
+			return nil, err
 		}
 	}
+	limit := limitFromQuery(p, 10, 100)
 
-	// Query author's blog posts (without reblogs) before date
-	// TODO: Implement query
-	_ = author
-	_ = startPermlink
-	_ = beforeDate
-	_ = limit
-
-	return []interface{}{}, nil
+	ids, err := m.cursor.GetPostIDsByBlogWithoutReblog(ctx.Request.Context(), author, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+	return m.postLoader.LoadPosts(ctx.Request.Context(), ids, 0)
 }
 
 // GetPostDiscussionsByPayout handles condenser_api.get_post_discussions_by_payout
+// Top-level posts, sorted by payout.
 func (m *MiscAPI) GetPostDiscussionsByPayout(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Similar to get_discussions_by_payout but only root posts
-	return m.getDiscussionsByPayout(ctx, params, true)
+	return m.getDiscussionsByPayout(ctx, params, "payout")
 }
 
 // GetCommentDiscussionsByPayout handles condenser_api.get_comment_discussions_by_payout
+// Comments, sorted by payout.
 func (m *MiscAPI) GetCommentDiscussionsByPayout(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// Similar to get_discussions_by_payout but only comments
-	return m.getDiscussionsByPayout(ctx, params, false)
+	return m.getDiscussionsByPayout(ctx, params, "payout_comments")
 }
 
 // getDiscussionsByPayout is a helper for payout queries
-func (m *MiscAPI) getDiscussionsByPayout(ctx *gin.Context, params json.RawMessage, rootOnly bool) (interface{}, error) {
-	var p map[string]interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
-		var arr []interface{}
-		if err2 := json.Unmarshal(params, &arr); err2 != nil {
-			return nil, apierrors.PublicError("invalid parameters format")
-		}
-		if len(arr) > 0 {
-			if mp, ok := arr[0].(map[string]interface{}); ok {
-				p = mp
-			}
-		}
+func (m *MiscAPI) getDiscussionsByPayout(ctx *gin.Context, params json.RawMessage, sort string) (interface{}, error) {
+	p, err := parseQueryParams(params, "start_author", "start_permlink", "limit", "tag", "truncate_body")
+	if err != nil {
+		return nil, err
 	}
 
-	startAuthor := ""
-	if sa, ok := p["start_author"].(string); ok {
-		startAuthor = sa
-	}
-	startPermlink := ""
-	if sp, ok := p["start_permlink"].(string); ok {
-		startPermlink = sp
-	}
-	limit := 20
-	if l, ok := p["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 100 {
-			limit = 100
+	startAuthor, _ := p["start_author"].(string)
+	if startAuthor != "" {
+		startAuthor, err = apierrors.ValidAccount(startAuthor, false)
+		if err != nil {
+			return nil, err
 		}
 	}
-	tag := ""
-	if t, ok := p["tag"].(string); ok {
-		tag = t
+	startPermlink, _ := p["start_permlink"].(string)
+	if startPermlink != "" {
+		if _, err := apierrors.ValidPermlink(startPermlink, false); err != nil {
+			return nil, err
+		}
 	}
-
-	// Use payout sort
-	sort := "payout"
-	if !rootOnly {
-		sort = "payout_comments"
-	}
+	limit := limitFromQuery(p, 20, 100)
+	tag, _ := p["tag"].(string)
+	truncateBody := truncateBodyFromQuery(p)
 
 	ids, err := m.cursor.GetPostIDsByQuery(ctx.Request.Context(), sort, startAuthor, startPermlink, limit, tag)
 	if err != nil {
 		return nil, err
 	}
-
-	result := make([]interface{}, len(ids))
-	for i, id := range ids {
-		result[i] = map[string]interface{}{
-			"id": id,
-		}
-	}
-
-	return result, nil
+	return m.postLoader.LoadPosts(ctx.Request.Context(), ids, truncateBody)
 }
 
 // GetTransaction handles condenser_api.get_transaction
+// Resolves the trx_id to a block via hive_trxid_block_num, then fetches the
+// full transaction from steemd.
 func (m *MiscAPI) GetTransaction(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p []interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
+	arr, err := parseListParams(params, 1, 1)
+	if err != nil {
 		return nil, err
 	}
-
-	if len(p) < 1 {
+	trxID := paramString(arr, 0)
+	if trxID == "" {
 		return nil, apierrors.PublicError("missing required parameter: trx_id")
 	}
 
-	trxID, _ := p[0].(string)
+	var blockNum int64
+	err = m.repo.DB().WithContext(ctx.Request.Context()).
+		Model(&models.TransactionBlock{}).
+		Where("trx_id = ?", trxID).
+		Select("block_num").
+		Scan(&blockNum).Error
+	if err != nil {
+		return nil, err
+	}
+	if blockNum == 0 {
+		return nil, apierrors.PublicError("trx_id does not exist")
+	}
 
-	// Query transaction from hive_trxid_block_num
-	// TODO: Implement transaction lookup
-	_ = trxID
+	if m.steemd == nil {
+		return nil, apierrors.PublicError("transaction lookup not yet implemented")
+	}
 
-	return nil, fmt.Errorf("transaction lookup not yet implemented")
-}
-
-// GetState handles condenser_api.get_state
-func (m *MiscAPI) GetState(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p []interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
+	block, err := m.steemd.GetBlock(ctx.Request.Context(), blockNum)
+	if err != nil {
 		return nil, err
 	}
 
-	if len(p) < 1 {
-		return nil, apierrors.PublicError("missing required parameter: path")
+	trxIDs, _ := block["transaction_ids"].([]string)
+	trxIndex := -1
+	for i, id := range trxIDs {
+		if id == trxID {
+			trxIndex = i
+			break
+		}
+	}
+	if trxIndex == -1 {
+		return nil, apierrors.PublicError("invalid trx_id")
+	}
+	transactions, _ := block["transactions"].([]interface{})
+	if trxIndex >= len(transactions) {
+		return nil, apierrors.PublicError("invalid trx_id")
 	}
 
-	path, _ := p[0].(string)
+	trx, ok := transactions[trxIndex].(map[string]interface{})
+	if !ok {
+		return nil, apierrors.PublicError("invalid trx_id")
+	}
+	trx["transaction_id"] = trxID
+	trx["block_num"] = blockNum
+	trx["transaction_num"] = trxIndex
+	return trx, nil
+}
 
-	// TODO: Implement get_state logic
-	// This is a complex method that handles various path formats
-	_ = path
-
-	return map[string]interface{}{
-		"feed_price": map[string]interface{}{},
-		"props":      map[string]interface{}{},
-		"tags":       map[string]interface{}{},
-		"accounts":   map[string]interface{}{},
-		"content":    map[string]interface{}{},
-	}, nil
+// GetState handles condenser_api.get_state
+// The full get_state router (path parsing + feed_price/props assembly) is a
+// large legacy-compat surface aimed at the retired condenser frontend; it is
+// intentionally not approximated here (per repo policy: explicit error
+// instead of a wrong-shaped stub).
+func (m *MiscAPI) GetState(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
+	return nil, apierrors.PublicError("get_state is not implemented; use bridge/condenser methods instead")
 }
 
 // GetAccountVotes handles condenser_api.get_account_votes (dummy method)
 func (m *MiscAPI) GetAccountVotes(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	// This method is no longer supported
 	return nil, apierrors.PublicError("get_account_votes is no longer supported")
+}
+
+// limitFromQuery extracts and clamps the limit from a query params map.
+func limitFromQuery(p map[string]interface{}, def, ubound int) int {
+	limit := def
+	if l, ok := p["limit"].(float64); ok {
+		limit = int(l)
+	}
+	if limit, err := apierrors.ValidLimit(limit, ubound); err == nil {
+		return limit
+	}
+	return def
+}
+
+// truncateBodyFromQuery extracts the optional truncate_body length.
+func truncateBodyFromQuery(p map[string]interface{}) int {
+	if tb, ok := p["truncate_body"].(float64); ok && tb > 0 {
+		return int(tb)
+	}
+	return 0
 }

--- a/internal/api/condenser/params.go
+++ b/internal/api/condenser/params.go
@@ -1,0 +1,97 @@
+package condenser
+
+import (
+	"encoding/json"
+
+	"github.com/steemit/hivemind/internal/apierrors"
+)
+
+// parseQueryParams accepts all parameter shapes steemd/condenser clients send
+// for discussion-style queries and returns a unified params map:
+//
+//  1. object:        {"tag": "steem", "limit": 1}
+//  2. nested query:  [{"tag": "steem", "limit": 1}]   (nested_query_compat)
+//  3. positional:    ["steem", "", "", 1]            (jussi/call style)
+//
+// For the positional form, posKeys maps array indices to query keys — e.g.
+// trending-style calls pass ("tag", "start_author", "start_permlink",
+// "limit") while replies-style calls pass ("start_author", "start_permlink",
+// "limit"), matching each method's legacy positional signature. Extra array
+// elements beyond posKeys are ignored, like steemd does.
+//
+// Mirrors the combination of legacy _strict_query and nested_query_compat.
+func parseQueryParams(params json.RawMessage, posKeys ...string) (map[string]interface{}, error) {
+	// Shape 1: a plain object.
+	var pMap map[string]interface{}
+	if err := json.Unmarshal(params, &pMap); err == nil {
+		return pMap, nil
+	}
+
+	// Shape 2/3: an array.
+	var arr []interface{}
+	if err := json.Unmarshal(params, &arr); err != nil {
+		return nil, apierrors.PublicError("invalid parameters format")
+	}
+	if len(arr) == 0 {
+		return map[string]interface{}{}, nil
+	}
+
+	// Nested query object inside the list.
+	if m, ok := arr[0].(map[string]interface{}); ok {
+		return m, nil
+	}
+
+	// Positional args mapped through posKeys.
+	out := map[string]interface{}{}
+	for i, key := range posKeys {
+		if i >= len(arr) || arr[i] == nil {
+			continue
+		}
+		switch v := arr[i].(type) {
+		case string:
+			if v != "" {
+				out[key] = v
+			}
+		case float64:
+			out[key] = v
+		}
+	}
+	return out, nil
+}
+
+// parseListParams validates a positional parameter list with a length window
+// (mirrors legacy _strict_list): exactly expectedLen params, or between
+// minLen and expectedLen when minLen is set.
+func parseListParams(params json.RawMessage, expectedLen int, minLen int) ([]interface{}, error) {
+	var arr []interface{}
+	if err := json.Unmarshal(params, &arr); err != nil {
+		return nil, apierrors.PublicError("invalid parameters format")
+	}
+	if minLen < 0 {
+		minLen = expectedLen
+	}
+	if len(arr) > expectedLen || len(arr) < minLen {
+		return nil, apierrors.Publicf("expected %d params", expectedLen)
+	}
+	return arr, nil
+}
+
+// paramString extracts a string element from a positional list.
+func paramString(arr []interface{}, idx int) string {
+	if idx < len(arr) {
+		if s, ok := arr[idx].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// paramInt extracts an int element from a positional list.
+func paramInt(arr []interface{}, idx int) int {
+	if idx < len(arr) {
+		if f, ok := arr[idx].(float64); ok {
+			return int(f)
+		}
+	}
+	return 0
+}

--- a/internal/api/condenser/tags.go
+++ b/internal/api/condenser/tags.go
@@ -2,6 +2,9 @@ package condenser
 
 import (
 	"encoding/json"
+	"fmt"
+
+	"github.com/steemit/hivemind/internal/apierrors"
 
 	"github.com/gin-gonic/gin"
 
@@ -20,30 +23,63 @@ func NewTagsAPI(repo *db.Repository, database *db.DB) *TagsAPI {
 }
 
 // GetTrendingTags handles condenser_api.get_trending_tags
+// Top tags among pending posts, with counts and total payouts.
 func (t *TagsAPI) GetTrendingTags(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	var p []interface{}
-	if err := json.Unmarshal(params, &p); err != nil {
+	arr, err := parseListParams(params, 2, 1)
+	if err != nil {
 		return nil, err
 	}
 
-	_ = "" // afterTag - TODO: Use for pagination
-	if len(p) > 0 {
-		_, _ = p[0].(string) // afterTag
+	startTag := paramString(arr, 0)
+	limit := 250
+	if len(arr) > 1 {
+		limit = paramInt(arr, 1)
 	}
-	limit := 100
-	if len(p) > 1 {
-		if l, ok := p[1].(float64); ok {
-			limit = int(l)
-			if limit > 100 {
-				limit = 100
-			}
-		}
+	if limit, err = apierrors.ValidLimit(limit, 250); err != nil {
+		return nil, err
 	}
 
-	// Query trending tags from hive_post_tags
-	// TODO: Implement proper trending tags query with payout aggregation
-	// For now, return empty result
-	return []interface{}{}, nil
+	seek := ""
+	args := []interface{}{}
+	if startTag != "" {
+		seek = `HAVING SUM(payout) <= (
+		    SELECT SUM(payout) FROM hive_posts_cache
+		     WHERE is_paidout = '0' AND category = ?)`
+		args = append(args, startTag)
+	}
+
+	sql := `
+	  SELECT category,
+	         COUNT(*) AS total_posts,
+	         SUM(CASE WHEN depth = 0 THEN 1 ELSE 0 END) AS top_posts,
+	         SUM(payout) AS total_payouts
+	    FROM hive_posts_cache
+	   WHERE is_paidout = '0'
+	GROUP BY category ` + seek + `
+	ORDER BY SUM(payout) DESC
+	   LIMIT ?`
+	args = append(args, limit)
+
+	var rows []struct {
+		Category     string  `gorm:"column:category"`
+		TotalPosts   int64   `gorm:"column:total_posts"`
+		TopPosts     int64   `gorm:"column:top_posts"`
+		TotalPayouts float64 `gorm:"column:total_payouts"`
+	}
+	if err := t.db.DB.WithContext(ctx.Request.Context()).Raw(sql, args...).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]interface{}, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, map[string]interface{}{
+			"name":          r.Category,
+			"comments":      r.TotalPosts - r.TopPosts,
+			"top_posts":     r.TopPosts,
+			"total_payouts": fmt.Sprintf("%.3f SBD", r.TotalPayouts),
+		})
+	}
+	return out, nil
 }
 
 // GetAccountReputations handles condenser_api.get_account_reputations

--- a/internal/api/hive/community.go
+++ b/internal/api/hive/community.go
@@ -1,26 +1,61 @@
 package hive
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
-	"github.com/steemit/hivemind/internal/apierrors"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
 )
 
 // CommunityAPI provides community-related Hive API methods
 type CommunityAPI struct {
-	repo *db.Repository
+	repo                 *db.Repository
+	recommendCommunities []string
 }
 
-// NewCommunityAPI creates a new community API
-func NewCommunityAPI(repo *db.Repository) *CommunityAPI {
-	return &CommunityAPI{repo: repo}
+// NewCommunityAPI creates a new community API. recommendCommunities is the
+// comma-separated config list (HIVE_RECOMMEND_COMMUNITIES) prepended by
+// list_top_communities, mirroring legacy conf recommend_communities.
+func NewCommunityAPI(repo *db.Repository, recommendCommunities string) *CommunityAPI {
+	var recommended []string
+	for _, name := range strings.Split(recommendCommunities, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			recommended = append(recommended, name)
+		}
+	}
+	return &CommunityAPI{repo: repo, recommendCommunities: recommended}
+}
+
+// getCommunityID resolves a community name (hive-xxxxx) to its id.
+// Returns 0 when not found. Mirrors legacy get_community_id.
+func (c *CommunityAPI) getCommunityID(ctx context.Context, name string) (int64, error) {
+	if name == "" {
+		return 0, apierrors.PublicError("no comm name specified")
+	}
+	var comm models.Community
+	err := c.repo.DB().WithContext(ctx).
+		Where("name = ?", name).
+		Select("id").
+		First(&comm).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return comm.ID, nil
 }
 
 // GetCommunity handles bridge.get_community
+// Full community object: metadata, leadership team, and (with observer)
+// subscription status, title and role.
 func (c *CommunityAPI) GetCommunity(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -28,19 +63,49 @@ func (c *CommunityAPI) GetCommunity(ctx *gin.Context, params json.RawMessage) (i
 	}
 
 	name, _ := pMap["name"].(string)
+	observer, _ := pMap["observer"].(string)
 	if name == "" {
 		return nil, apierrors.PublicError("missing required parameter: name")
 	}
 
-	// TODO: Query community from hive_communities
-	_ = name
+	cid, err := c.getCommunityID(ctx.Request.Context(), name)
+	if err != nil {
+		return nil, err
+	}
+	if cid == 0 {
+		return nil, apierrors.PublicError("community not found")
+	}
 
-	return map[string]interface{}{
-		"name": name,
-	}, nil
+	communities, err := c.loadCommunities(ctx.Request.Context(), []int64{cid}, false)
+	if err != nil {
+		return nil, err
+	}
+
+	comm := communities[cid]
+	if comm == nil {
+		return nil, apierrors.PublicError("community not found")
+	}
+
+	if observer != "" {
+		observerID, err := c.getAccountID(ctx.Request.Context(), observer)
+		if err != nil {
+			return nil, err
+		}
+		if observerID != 0 {
+			if err := c.appendObserverRoles(ctx.Request.Context(), communities, observerID); err != nil {
+				return nil, err
+			}
+			if err := c.appendObserverSubs(ctx.Request.Context(), communities, observerID); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return comm, nil
 }
 
 // GetCommunityContext handles bridge.get_community_context
+// For a community/account pair: returns role, title, subscribed state.
 func (c *CommunityAPI) GetCommunityContext(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -49,73 +114,254 @@ func (c *CommunityAPI) GetCommunityContext(ctx *gin.Context, params json.RawMess
 
 	name, _ := pMap["name"].(string)
 	account, _ := pMap["account"].(string)
-
 	if name == "" || account == "" {
-		return nil, fmt.Errorf("missing required parameters: name, account")
+		return nil, apierrors.PublicError("missing required parameters: name, account")
 	}
 
-	// TODO: Query community context (role, title, subscribed)
+	dbCtx := ctx.Request.Context()
+	cid, err := c.getCommunityID(dbCtx, name)
+	if err != nil {
+		return nil, err
+	}
+	if cid == 0 {
+		return nil, apierrors.PublicError("community not found")
+	}
+	aid, err := c.getAccountID(dbCtx, account)
+	if err != nil {
+		return nil, err
+	}
+	if aid == 0 {
+		return nil, apierrors.PublicError("account not found")
+	}
+
+	var role struct {
+		RoleID int16  `gorm:"column:role_id"`
+		Title  string `gorm:"column:title"`
+	}
+	err = c.repo.DB().WithContext(dbCtx).Raw(
+		`SELECT role_id, title FROM hive_roles
+		  WHERE account_id = ? AND community_id = ?`, aid, cid,
+	).Scan(&role).Error
+	if err != nil {
+		return nil, err
+	}
+
+	var subscribed bool
+	err = c.repo.DB().WithContext(dbCtx).Raw(
+		`SELECT EXISTS(
+		    SELECT 1 FROM hive_subscriptions
+		     WHERE account_id = ? AND community_id = ?)`, aid, cid,
+	).Scan(&subscribed).Error
+	if err != nil {
+		return nil, err
+	}
+
+	roleName := roleIDToString(role.RoleID)
+	if roleName == "" {
+		roleName = "guest"
+	}
 	return map[string]interface{}{
-		"role":       "member",
-		"title":      "",
-		"subscribed": false,
+		"role":       roleName,
+		"title":      role.Title,
+		"subscribed": subscribed,
 	}, nil
 }
 
 // ListCommunities handles bridge.list_communities
+// Paginated community list with optional full-text query and sort.
 func (c *CommunityAPI) ListCommunities(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
 		return nil, apierrors.PublicError("invalid parameters format")
 	}
 
-	last := ""
-	if l, ok := pMap["last"].(string); ok {
-		last = l
+	last, _ := pMap["last"].(string)
+	query, _ := pMap["query"].(string)
+	sortKey, _ := pMap["sort"].(string)
+	if sortKey == "" {
+		sortKey = "rank"
 	}
-	limit := 100
-	if l, ok := pMap["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 100 {
-			limit = 100
+	observer, _ := pMap["observer"].(string)
+	limit := validLimitParam(pMap, 100, 100)
+
+	if sortKey != "rank" && sortKey != "new" && sortKey != "subs" {
+		return nil, apierrors.PublicError("invalid sort")
+	}
+
+	var field, order string
+	switch sortKey {
+	case "rank":
+		field, order = "rank", "ASC"
+	case "new":
+		field, order = "created_at", "DESC"
+	case "subs":
+		field, order = "subscribers", "DESC"
+	}
+
+	where := []string{}
+	args := []interface{}{}
+	if query != "" {
+		where = append(where, "to_tsvector('english', title || ' ' || about) @@ plainto_tsquery(?)")
+		args = append(args, query)
+	}
+	if field == "rank" {
+		where = append(where, "rank > 0")
+	}
+	if last != "" {
+		cmp := ">"
+		if order == "DESC" {
+			cmp = "<"
+		}
+		where = append(where, field+" "+cmp+" (SELECT "+field+" FROM hive_communities WHERE name = ?)")
+		args = append(args, last)
+	}
+
+	sql := "SELECT id FROM hive_communities"
+	if len(where) > 0 {
+		sql += " WHERE " + strings.Join(where, " AND ")
+	}
+	sql += " ORDER BY " + field + " " + order + " LIMIT ?"
+	args = append(args, limit)
+
+	dbCtx := ctx.Request.Context()
+	var ids []int64
+	if err := c.repo.DB().WithContext(dbCtx).Raw(sql, args...).Scan(&ids).Error; err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return []interface{}{}, nil
+	}
+
+	communities, err := c.loadCommunities(dbCtx, ids, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if observer != "" {
+		observerID, err := c.getAccountID(dbCtx, observer)
+		if err != nil {
+			return nil, err
+		}
+		if observerID != 0 {
+			if err := c.appendObserverSubs(dbCtx, communities, observerID); err != nil {
+				return nil, err
+			}
+			if err := c.appendObserverRoles(dbCtx, communities, observerID); err != nil {
+				return nil, err
+			}
 		}
 	}
+	if err := c.appendAdmins(dbCtx, communities); err != nil {
+		return nil, err
+	}
 
-	// TODO: Query communities from hive_communities
-	_ = last
-	_ = limit
-
-	return []interface{}{}, nil
+	out := make([]interface{}, 0, len(ids))
+	for _, id := range ids {
+		if comm := communities[id]; comm != nil {
+			out = append(out, comm)
+		}
+	}
+	return out, nil
 }
 
 // ListTopCommunities handles bridge.list_top_communities
+// Configured recommended communities first, then by rank. Returns (name, title) pairs.
 func (c *CommunityAPI) ListTopCommunities(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// TODO: Query top communities by rank
-	return []interface{}{}, nil
+	var pMap map[string]interface{}
+	if err := json.Unmarshal(params, &pMap); err != nil {
+		// Tolerate empty params ([] or null) like legacy no-arg calls.
+		pMap = map[string]interface{}{}
+	}
+	limit := validLimitParam(pMap, 25, 99)
+	if limit >= 100 {
+		return nil, apierrors.PublicError("limit must be below 100")
+	}
+
+	custom := []interface{}{}
+	if len(c.recommendCommunities) > 0 {
+		var rows []struct {
+			Name  string `gorm:"column:name"`
+			Title string `gorm:"column:title"`
+		}
+		if err := c.repo.DB().WithContext(ctx.Request.Context()).
+			Table("hive_communities").
+			Select("name, title").
+			Where("name IN ?", c.recommendCommunities).
+			Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range rows {
+			custom = append(custom, []interface{}{r.Name, r.Title})
+		}
+	}
+
+	if len(custom) >= limit {
+		return custom[:limit], nil
+	}
+
+	var ranked []struct {
+		Name  string `gorm:"column:name"`
+		Title string `gorm:"column:title"`
+	}
+	rankQuery := c.repo.DB().WithContext(ctx.Request.Context()).
+		Table("hive_communities").
+		Select("name, title").
+		Where("rank > 0")
+	// Don't repeat communities already covered by the recommended list.
+	if len(c.recommendCommunities) > 0 {
+		rankQuery = rankQuery.Where("name NOT IN ?", c.recommendCommunities)
+	}
+	if err := rankQuery.
+		Order("rank").
+		Limit(limit - len(custom)).
+		Find(&ranked).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range ranked {
+		custom = append(custom, []interface{}{r.Name, r.Title})
+	}
+	return custom, nil
 }
 
 // ListPopCommunities handles bridge.list_pop_communities
+// Communities ranked by new subscribers in the last 30 days.
 func (c *CommunityAPI) ListPopCommunities(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
 		return nil, apierrors.PublicError("invalid parameters format")
 	}
+	limit := validLimitParam(pMap, 25, 25)
 
-	limit := 25
-	if l, ok := pMap["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 25 {
-			limit = 25
-		}
+	var rows []struct {
+		Name  string `gorm:"column:name"`
+		Title string `gorm:"column:title"`
+	}
+	cutoff := time.Now().AddDate(0, 0, -30)
+	if err := c.repo.DB().WithContext(ctx.Request.Context()).Raw(
+		`SELECT c.name, c.title
+		   FROM hive_communities c
+		   JOIN (
+		            SELECT community_id, COUNT(*) AS newsubs
+		              FROM hive_subscriptions
+		             WHERE created_at > ?
+		          GROUP BY community_id
+		       ) stats
+		     ON stats.community_id = c.id
+		 ORDER BY newsubs DESC
+		    LIMIT ?`, cutoff, limit,
+	).Scan(&rows).Error; err != nil {
+		return nil, err
 	}
 
-	// TODO: Query communities by new subscriber count
-	_ = limit
-
-	return []interface{}{}, nil
+	out := make([]interface{}, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, []interface{}{r.Name, r.Title})
+	}
+	return out, nil
 }
 
 // ListCommunityRoles handles bridge.list_community_roles
+// Community members with a non-guest role, ordered by role then name.
 func (c *CommunityAPI) ListCommunityRoles(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -126,14 +372,69 @@ func (c *CommunityAPI) ListCommunityRoles(ctx *gin.Context, params json.RawMessa
 	if community == "" {
 		return nil, apierrors.PublicError("missing required parameter: community")
 	}
+	last, _ := pMap["last"].(string)
+	limit := validLimitParam(pMap, 50, 100)
 
-	// TODO: Query roles from hive_roles
-	_ = community
+	dbCtx := ctx.Request.Context()
+	cid, err := c.getCommunityID(dbCtx, community)
+	if err != nil {
+		return nil, err
+	}
 
-	return []interface{}{}, nil
+	seek := ""
+	args := []interface{}{cid}
+	if last != "" {
+		// Resolve the start account's current role in this community
+		// (guest when they have no role row). Unknown account = invalid start.
+		var lrole struct {
+			RoleID int16 `gorm:"column:role_id"`
+		}
+		err := c.repo.DB().WithContext(dbCtx).Raw(
+			`SELECT r.role_id FROM hive_roles r
+			   JOIN hive_accounts a ON r.account_id = a.id
+			  WHERE a.name = ? AND r.community_id = ?`, last, cid,
+		).Scan(&lrole).Error
+		if err != nil {
+			return nil, err
+		}
+		var exists int64
+		if err := c.repo.DB().WithContext(dbCtx).Raw(
+			`SELECT COUNT(*) FROM hive_accounts WHERE name = ?`, last,
+		).Scan(&exists).Error; err != nil {
+			return nil, err
+		}
+		if exists == 0 {
+			return nil, apierrors.PublicError("invalid start")
+		}
+		seek = ` AND (r.role_id < ? OR (r.role_id = ? AND a.name > ?))`
+		args = append(args, lrole.RoleID, lrole.RoleID, last)
+	}
+
+	sql := `SELECT a.name, r.role_id, r.title FROM hive_roles r
+	          JOIN hive_accounts a ON r.account_id = a.id
+	         WHERE r.community_id = ?` + seek + `
+	           AND r.role_id != 0
+	      ORDER BY r.role_id DESC, a.name LIMIT ?`
+	args = append(args, limit)
+
+	var rows []struct {
+		Name   string `gorm:"column:name"`
+		RoleID int16  `gorm:"column:role_id"`
+		Title  string `gorm:"column:title"`
+	}
+	if err := c.repo.DB().WithContext(dbCtx).Raw(sql, args...).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]interface{}, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, []interface{}{r.Name, roleIDToString(r.RoleID), r.Title})
+	}
+	return out, nil
 }
 
 // ListSubscribers handles bridge.list_subscribers
+// Most recent 250 subscribers of a community, with role and title.
 func (c *CommunityAPI) ListSubscribers(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -145,13 +446,51 @@ func (c *CommunityAPI) ListSubscribers(ctx *gin.Context, params json.RawMessage)
 		return nil, apierrors.PublicError("missing required parameter: community")
 	}
 
-	// TODO: Query subscribers from hive_subscriptions
-	_ = community
+	dbCtx := ctx.Request.Context()
+	cid, err := c.getCommunityID(dbCtx, community)
+	if err != nil {
+		return nil, err
+	}
+	if cid == 0 {
+		return nil, apierrors.PublicError("community not found")
+	}
 
-	return []interface{}{}, nil
+	var rows []struct {
+		Name      string    `gorm:"column:name"`
+		RoleID    *int16    `gorm:"column:role_id"`
+		Title     *string   `gorm:"column:title"`
+		CreatedAt time.Time `gorm:"column:created_at"`
+	}
+	if err := c.repo.DB().WithContext(dbCtx).Raw(
+		`SELECT ha.name, hr.role_id, hr.title, hs.created_at
+		   FROM hive_subscriptions hs
+		  LEFT JOIN hive_roles hr ON hs.account_id = hr.account_id
+		                          AND hs.community_id = hr.community_id
+		   JOIN hive_accounts ha ON hs.account_id = ha.id
+		  WHERE hs.community_id = ?
+	       ORDER BY hs.created_at DESC
+	          LIMIT 250`, cid,
+	).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]interface{}, 0, len(rows))
+	for _, r := range rows {
+		role := int16(0)
+		if r.RoleID != nil {
+			role = *r.RoleID
+		}
+		title := ""
+		if r.Title != nil {
+			title = *r.Title
+		}
+		out = append(out, []interface{}{r.Name, roleIDToString(role), title, r.CreatedAt.Format(time.RFC3339)})
+	}
+	return out, nil
 }
 
 // ListAllSubscriptions handles bridge.list_all_subscriptions
+// All communities `account` subscribes to, with role and title in each.
 func (c *CommunityAPI) ListAllSubscriptions(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -163,8 +502,278 @@ func (c *CommunityAPI) ListAllSubscriptions(ctx *gin.Context, params json.RawMes
 		return nil, apierrors.PublicError("missing required parameter: account")
 	}
 
-	// TODO: Query subscriptions from hive_subscriptions
-	_ = account
+	dbCtx := ctx.Request.Context()
+	accountID, err := c.getAccountID(dbCtx, account)
+	if err != nil {
+		return nil, err
+	}
+	if accountID == 0 {
+		return nil, apierrors.Publicf("account not found: `%s`", account)
+	}
 
-	return []interface{}{}, nil
+	var rows []struct {
+		Name   string  `gorm:"column:name"`
+		Title  string  `gorm:"column:title"`
+		RoleID *int16  `gorm:"column:role_id"`
+		RTitle *string `gorm:"column:rtitle"`
+	}
+	if err := c.repo.DB().WithContext(dbCtx).Raw(
+		`SELECT c.name, c.title, r.role_id, r.title AS rtitle
+		   FROM hive_communities c
+		   JOIN hive_subscriptions s ON c.id = s.community_id
+		  LEFT JOIN hive_roles r ON r.account_id = s.account_id
+		                         AND r.community_id = c.id
+		  WHERE s.account_id = ?
+	       ORDER BY COALESCE(r.role_id, 0) DESC, c.rank`, accountID,
+	).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]interface{}, 0, len(rows))
+	for _, r := range rows {
+		role := int16(0)
+		if r.RoleID != nil {
+			role = *r.RoleID
+		}
+		title := ""
+		if r.RTitle != nil {
+			title = *r.RTitle
+		}
+		out = append(out, []interface{}{r.Name, r.Title, roleIDToString(role), title})
+	}
+	return out, nil
+}
+
+// loadCommunities builds community objects keyed by id. When lite is false
+// the description/flag_text/settings fields and the leadership team are
+// included. Mirrors legacy load_communities.
+func (c *CommunityAPI) loadCommunities(ctx context.Context, ids []int64, lite bool) (map[int64]map[string]interface{}, error) {
+	if len(ids) == 0 {
+		return map[int64]map[string]interface{}{}, nil
+	}
+
+	var comms []models.Community
+	if err := c.repo.DB().WithContext(ctx).
+		Where("id IN ?", ids).
+		Find(&comms).Error; err != nil {
+		return nil, err
+	}
+
+	out := make(map[int64]map[string]interface{}, len(comms))
+	teamIDs := make([]int64, 0)
+	for _, comm := range comms {
+		title := comm.Title
+		if title == "" {
+			title = "@" + comm.Name
+		}
+		obj := map[string]interface{}{
+			"id":          comm.ID,
+			"name":        comm.Name,
+			"title":       title,
+			"about":       comm.About,
+			"lang":        comm.Lang,
+			"type_id":     comm.TypeID,
+			"is_nsfw":     comm.IsNSFW,
+			"subscribers": comm.Subscribers,
+			"sum_pending": comm.SumPending,
+			"num_pending": comm.NumPending,
+			"num_authors": comm.NumAuthors,
+			"created_at":  comm.CreatedAt.Format(time.RFC3339),
+			"avatar_url":  comm.AvatarURL,
+			"context":     map[string]interface{}{},
+		}
+		if !lite {
+			obj["description"] = comm.Description
+			obj["flag_text"] = comm.FlagText
+			settings := map[string]interface{}{}
+			if comm.Settings.Valid && comm.Settings.String != "" {
+				_ = json.Unmarshal([]byte(comm.Settings.String), &settings)
+			}
+			obj["settings"] = settings
+			teamIDs = append(teamIDs, comm.ID)
+		}
+		out[comm.ID] = obj
+	}
+
+	// Attach leadership team (roles 4-8) for full loads.
+	if len(teamIDs) > 0 {
+		var team []struct {
+			CommunityID int64  `gorm:"column:community_id"`
+			Name        string `gorm:"column:name"`
+			RoleID      int16  `gorm:"column:role_id"`
+			Title       string `gorm:"column:title"`
+		}
+		if err := c.repo.DB().WithContext(ctx).Raw(
+			`SELECT r.community_id, a.name, r.role_id, r.title
+			   FROM hive_roles r
+			   JOIN hive_accounts a ON r.account_id = a.id
+			  WHERE r.community_id IN ? AND r.role_id BETWEEN 4 AND 8
+		   ORDER BY r.role_id DESC`, teamIDs,
+		).Scan(&team).Error; err != nil {
+			return nil, err
+		}
+		teamByCID := make(map[int64][]interface{})
+		for _, t := range team {
+			teamByCID[t.CommunityID] = append(teamByCID[t.CommunityID],
+				[]interface{}{t.Name, roleIDToString(t.RoleID), t.Title})
+		}
+		for _, cid := range teamIDs {
+			if obj := out[cid]; obj != nil {
+				if team, ok := teamByCID[cid]; ok {
+					obj["team"] = team
+				} else {
+					obj["team"] = []interface{}{}
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// appendObserverRoles fills context.role / context.title for each community
+// relative to the observer. Mirrors legacy _append_observer_roles.
+func (c *CommunityAPI) appendObserverRoles(ctx context.Context, communities map[int64]map[string]interface{}, observerID int64) error {
+	ids := make([]int64, 0, len(communities))
+	for cid := range communities {
+		ids = append(ids, cid)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	var roles []models.Role
+	if err := c.repo.DB().WithContext(ctx).
+		Where("account_id = ? AND community_id IN ?", observerID, ids).
+		Find(&roles).Error; err != nil {
+		return err
+	}
+
+	roleByCID := make(map[int64]models.Role, len(roles))
+	for _, r := range roles {
+		roleByCID[r.CommunityID] = r
+	}
+	for cid, comm := range communities {
+		contextObj, _ := comm["context"].(map[string]interface{})
+		if contextObj == nil {
+			contextObj = map[string]interface{}{}
+			comm["context"] = contextObj
+		}
+		if r, ok := roleByCID[cid]; ok {
+			contextObj["role"] = roleIDToString(r.RoleID)
+			contextObj["title"] = r.Title
+		} else {
+			contextObj["role"] = "guest"
+			contextObj["title"] = ""
+		}
+	}
+	return nil
+}
+
+// appendObserverSubs fills context.subscribed for each community relative to
+// the observer. Mirrors legacy _append_observer_subs.
+func (c *CommunityAPI) appendObserverSubs(ctx context.Context, communities map[int64]map[string]interface{}, observerID int64) error {
+	ids := make([]int64, 0, len(communities))
+	for cid := range communities {
+		ids = append(ids, cid)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	var subIDs []int64
+	if err := c.repo.DB().WithContext(ctx).
+		Model(&models.Subscription{}).
+		Where("account_id = ? AND community_id IN ?", observerID, ids).
+		Pluck("community_id", &subIDs).Error; err != nil {
+		return err
+	}
+
+	subSet := make(map[int64]bool, len(subIDs))
+	for _, cid := range subIDs {
+		subSet[cid] = true
+	}
+	for cid, comm := range communities {
+		contextObj, _ := comm["context"].(map[string]interface{})
+		if contextObj == nil {
+			contextObj = map[string]interface{}{}
+			comm["context"] = contextObj
+		}
+		contextObj["subscribed"] = subSet[cid]
+	}
+	return nil
+}
+
+// appendAdmins fills the admins list (role_id = 6) for each community.
+// Mirrors legacy _append_admins.
+func (c *CommunityAPI) appendAdmins(ctx context.Context, communities map[int64]map[string]interface{}) error {
+	ids := make([]int64, 0, len(communities))
+	for cid := range communities {
+		ids = append(ids, cid)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	var rows []struct {
+		CommunityID int64  `gorm:"column:community_id"`
+		Name        string `gorm:"column:name"`
+	}
+	if err := c.repo.DB().WithContext(ctx).Raw(
+		`SELECT r.community_id, a.name
+		   FROM hive_roles r
+		   JOIN hive_accounts a ON r.account_id = a.id
+		  WHERE r.role_id = 6 AND r.community_id IN ?`, ids,
+	).Scan(&rows).Error; err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		comm := communities[row.CommunityID]
+		if comm == nil {
+			continue
+		}
+		admins, _ := comm["admins"].([]interface{})
+		comm["admins"] = append(admins, row.Name)
+	}
+	return nil
+}
+
+// getAccountID resolves an account name to its hive_accounts.id.
+func (c *CommunityAPI) getAccountID(ctx context.Context, name string) (int64, error) {
+	if name == "" {
+		return 0, apierrors.PublicError("no account name specified")
+	}
+	var acc models.Account
+	err := c.repo.DB().WithContext(ctx).
+		Where("name = ?", name).
+		Select("id").
+		First(&acc).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return acc.ID, nil
+}
+
+// roleIDToString maps a numeric role_id to its display name; unknown ids map
+// to "guest" (legacy ROLES lookup falls back through dict.get in callers).
+func roleIDToString(roleID int16) string {
+	switch roleID {
+	case -2:
+		return "muted"
+	case 0:
+		return "guest"
+	case 2:
+		return "member"
+	case 4:
+		return "mod"
+	case 6:
+		return "admin"
+	case 8:
+		return "owner"
+	}
+	return "guest"
 }

--- a/internal/api/hive/hive_test.go
+++ b/internal/api/hive/hive_test.go
@@ -1,0 +1,344 @@
+package hive
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/models"
+)
+
+// newTestDB creates a dedicated database (hive_hive_test) for this package so
+// it can run concurrently with other packages' integration suites.
+func newTestDB(t *testing.T) string {
+	t.Helper()
+	baseURL := os.Getenv("HIVE_TEST_DATABASE_URL")
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse db url: %v", err)
+	}
+	u.Path = "/postgres"
+	maintDSN := u.String()
+
+	raw, err := sql.Open("pgx", maintDSN)
+	if err != nil {
+		t.Fatalf("open maintenance conn: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`DROP DATABASE IF EXISTS hive_hive_test;`); err != nil {
+		t.Fatalf("drop test db: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE DATABASE hive_hive_test;`); err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	u.Path = "/hive_hive_test"
+	return u.String()
+}
+
+func resetSchema(t *testing.T, dbURL string) {
+	t.Helper()
+	raw, err := sql.Open("pgx", dbURL)
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+}
+
+// call invokes a hive API handler with a JSON params map.
+func call(t *testing.T, handler func(*gin.Context, json.RawMessage) (interface{}, error), params map[string]interface{}) interface{} {
+	t.Helper()
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("POST", "/", nil)
+	raw, _ := json.Marshal(params)
+	result, err := handler(ctx, raw)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return result
+}
+
+// TestCommunityAndPublicMethods covers the hive_api community methods and
+// the follow/blog list methods against a real Postgres schema.
+//
+// Requires a live Postgres; skipped when HIVE_TEST_DATABASE_URL is not set.
+func TestCommunityAndPublicMethods(t *testing.T) {
+	if os.Getenv("HIVE_TEST_DATABASE_URL") == "" {
+		t.Skip("HIVE_TEST_DATABASE_URL not set; skipping hive_api integration test")
+	}
+	dbURL := newTestDB(t)
+	resetSchema(t, dbURL)
+	if err := db.RunMigrations(dbURL, 0); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open gorm: %v", err)
+	}
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatalf("raw db: %v", err)
+	}
+	defer sqlDB.Close()
+
+	seedHiveFixture(t, gdb)
+
+	gin.SetMode(gin.TestMode)
+	repo := db.NewRepository(gdb)
+	wrapped := &db.DB{DB: gdb}
+	public := NewPublicAPI(repo, wrapped)
+	community := NewCommunityAPI(repo, "hive-123456")
+
+	// --- community methods ---
+
+	comm := call(t, community.GetCommunity, map[string]interface{}{"name": "hive-123456"}).(map[string]interface{})
+	if comm["name"] != "hive-123456" || comm["title"] != "Test Community" {
+		t.Errorf("get_community: got %v", comm)
+	}
+	team, ok := comm["team"].([]interface{})
+	if !ok || len(team) != 1 {
+		t.Fatalf("get_community: expected team of 1, got %v", comm["team"])
+	}
+	if team[0].([]interface{})[0] != "alice" || team[0].([]interface{})[1] != "owner" {
+		t.Errorf("get_community team: got %v", team[0])
+	}
+
+	// Observer context: alice is owner + subscribed.
+	commObs := call(t, community.GetCommunity, map[string]interface{}{"name": "hive-123456", "observer": "alice"}).(map[string]interface{})
+	context := commObs["context"].(map[string]interface{})
+	if context["role"] != "owner" || context["subscribed"] != true {
+		t.Errorf("get_community observer context: got %v", context)
+	}
+
+	ctxRes := call(t, community.GetCommunityContext, map[string]interface{}{"name": "hive-123456", "account": "bob"}).(map[string]interface{})
+	if ctxRes["role"] != "member" || ctxRes["subscribed"] != true {
+		t.Errorf("get_community_context bob: got %v", ctxRes)
+	}
+	ctxRes = call(t, community.GetCommunityContext, map[string]interface{}{"name": "hive-123456", "account": "carol"}).(map[string]interface{})
+	if ctxRes["role"] != "guest" || ctxRes["subscribed"] != false {
+		t.Errorf("get_community_context carol: got %v", ctxRes)
+	}
+
+	list := call(t, community.ListCommunities, map[string]interface{}{}).([]interface{})
+	if len(list) != 1 || list[0].(map[string]interface{})["name"] != "hive-123456" {
+		t.Errorf("list_communities: got %v", list)
+	}
+
+	top := call(t, community.ListTopCommunities, map[string]interface{}{"limit": 5}).([]interface{})
+	if len(top) != 1 || top[0].([]interface{})[0] != "hive-123456" {
+		t.Errorf("list_top_communities: got %v", top)
+	}
+
+	pop := call(t, community.ListPopCommunities, map[string]interface{}{}).([]interface{})
+	if len(pop) != 1 || pop[0].([]interface{})[0] != "hive-123456" {
+		t.Errorf("list_pop_communities: got %v", pop)
+	}
+
+	roles := call(t, community.ListCommunityRoles, map[string]interface{}{"community": "hive-123456"}).([]interface{})
+	if len(roles) != 2 { // alice owner, bob member
+		t.Fatalf("list_community_roles: expected 2, got %v", roles)
+	}
+	if roles[0].([]interface{})[0] != "alice" || roles[0].([]interface{})[1] != "owner" {
+		t.Errorf("list_community_roles order: got %v", roles[0])
+	}
+
+	subs := call(t, community.ListSubscribers, map[string]interface{}{"community": "hive-123456"}).([]interface{})
+	if len(subs) != 2 {
+		t.Fatalf("list_subscribers: expected 2, got %v", subs)
+	}
+
+	allSubs := call(t, community.ListAllSubscriptions, map[string]interface{}{"account": "bob"}).([]interface{})
+	if len(allSubs) != 1 {
+		t.Fatalf("list_all_subscriptions: expected 1, got %v", allSubs)
+	}
+	if allSubs[0].([]interface{})[0] != "hive-123456" || allSubs[0].([]interface{})[2] != "member" {
+		t.Errorf("list_all_subscriptions: got %v", allSubs[0])
+	}
+
+	// --- public methods ---
+
+	acc := call(t, public.GetAccount, map[string]interface{}{"name": "alice"}).(map[string]interface{})
+	if acc["name"] != "alice" || acc["location"] != nil && acc["location"] != "" {
+		t.Errorf("get_account: got %v", acc)
+	}
+	if _, ok := acc["website"]; !ok {
+		t.Errorf("get_account: non-lite profile fields missing: %v", acc)
+	}
+
+	accs := call(t, public.GetAccounts, map[string]interface{}{"names": []interface{}{"alice", "bob"}}).([]map[string]interface{})
+	if len(accs) != 2 || accs[0]["name"] != "alice" {
+		t.Fatalf("get_accounts: got %v", accs)
+	}
+	if _, ok := accs[0]["website"]; ok {
+		t.Errorf("get_accounts: lite shape should omit website")
+	}
+
+	followers := call(t, public.ListFollowers, map[string]interface{}{"account": "bob"}).([]map[string]interface{})
+	if len(followers) != 1 || followers[0]["name"] != "alice" {
+		t.Fatalf("list_followers: got %v", followers)
+	}
+	// Pure-ignore (state=2) follows are excluded from list_following
+	// (legacy filters state IN (1,3) for the 'blog' follow type).
+	following := call(t, public.ListFollowing, map[string]interface{}{"account": "alice"}).([]map[string]interface{})
+	if len(following) != 2 || following[0]["name"] != "bob" || following[1]["name"] != "carol" {
+		t.Fatalf("list_following: got %v", following)
+	}
+
+	muted := call(t, public.ListAllMuted, map[string]interface{}{"account": "alice"}).([]string)
+	if len(muted) != 1 || muted[0] != "mallory" {
+		t.Fatalf("list_all_muted: got %v", muted)
+	}
+
+	// blog: alice's own post + reblogged bob post.
+	blog := call(t, public.ListAccountBlog, map[string]interface{}{"account": "alice"}).(map[string]interface{})
+	blogPosts := blog["posts"].([]map[string]interface{})
+	if len(blogPosts) != 2 || blogPosts[0]["url"] != "bob/post-b" {
+		t.Fatalf("list_account_blog: got %v", blogPosts)
+	}
+
+	// posts: alice's own comments (comment-x).
+	posts := call(t, public.ListAccountPosts, map[string]interface{}{"account": "alice"}).(map[string]interface{})
+	postsList := posts["posts"].([]map[string]interface{})
+	if len(postsList) != 1 || postsList[0]["url"] != "alice/comment-x" {
+		t.Fatalf("list_account_posts: got %v", postsList)
+	}
+
+	// feed: bob's post surfaces with reblogged_by attribution.
+	feed := call(t, public.ListAccountFeed, map[string]interface{}{"account": "alice"}).(map[string]interface{})
+	feedPosts := feed["posts"].([]map[string]interface{})
+	if len(feedPosts) != 1 || feedPosts[0]["url"] != "bob/post-b" {
+		t.Fatalf("list_account_feed: got %v", feedPosts)
+	}
+	if rby := feedPosts[0]["reblogged_by"]; rby == nil {
+		t.Errorf("list_account_feed: expected reblogged_by on feed post")
+	}
+}
+
+// seedHiveFixture builds accounts, a community with roles/subscriptions,
+// follows (one muted), posts with cache rows, and feed cache entries.
+func seedHiveFixture(t *testing.T, gdb *gorm.DB) {
+	t.Helper()
+	now := time.Now().UTC()
+
+	for _, name := range []string{"alice", "bob", "carol", "mallory"} {
+		if err := gdb.Create(&models.Account{Name: name, CreatedAt: now, Rank: 1}).Error; err != nil {
+			t.Fatalf("seed account %s: %v", name, err)
+		}
+	}
+	var alice, bob models.Account
+	if err := gdb.Where("name = ?", "alice").First(&alice).Error; err != nil {
+		t.Fatalf("load alice: %v", err)
+	}
+	if err := gdb.Where("name = ?", "bob").First(&bob).Error; err != nil {
+		t.Fatalf("load bob: %v", err)
+	}
+
+	// Community with owner alice and member bob; both subscribed.
+	comm := models.Community{Name: "hive-123456", Title: "Test Community", Rank: 1, CreatedAt: now}
+	comm.ID = 123456
+	if err := gdb.Create(&comm).Error; err != nil {
+		t.Fatalf("seed community: %v", err)
+	}
+	roles := []models.Role{
+		{CommunityID: comm.ID, AccountID: alice.ID, RoleID: 8, CreatedAt: now},
+		{CommunityID: comm.ID, AccountID: bob.ID, RoleID: 2, CreatedAt: now},
+	}
+	for i := range roles {
+		if err := gdb.Create(&roles[i]).Error; err != nil {
+			t.Fatalf("seed role: %v", err)
+		}
+	}
+	subs := []models.Subscription{
+		{CommunityID: comm.ID, AccountID: alice.ID, CreatedAt: now},
+		{CommunityID: comm.ID, AccountID: bob.ID, CreatedAt: now},
+	}
+	for i := range subs {
+		if err := gdb.Create(&subs[i]).Error; err != nil {
+			t.Fatalf("seed subscription: %v", err)
+		}
+	}
+
+	// alice follows bob + carol (blog) and mallory (ignored only).
+	follows := []models.Follow{
+		{FollowerID: alice.ID, FollowingID: bob.ID, State: 1, CreatedAt: now.Add(-2 * time.Hour)},
+		{FollowerID: alice.ID, FollowingID: mustAccountID(t, gdb, "carol"), State: 1, CreatedAt: now.Add(-30 * time.Hour)},
+		{FollowerID: alice.ID, FollowingID: mustAccountID(t, gdb, "mallory"), State: 2, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+	for i := range follows {
+		if err := gdb.Create(&follows[i]).Error; err != nil {
+			t.Fatalf("seed follow: %v", err)
+		}
+	}
+
+	// Posts: alice/post-a (root), bob/post-b (root), alice/comment-x (comment on bob's).
+	mk := func(id int64, parent int64, author, permlink string, depth int16) models.Post {
+		p := models.Post{Author: author, Permlink: permlink, Category: "test", CreatedAt: now, Depth: depth}
+		p.ID = id
+		if parent != 0 {
+			p.ParentID.Valid = true
+			p.ParentID.Int64 = parent
+		}
+		return p
+	}
+	posts := []models.Post{
+		mk(1, 0, "alice", "post-a", 0),
+		mk(2, 0, "bob", "post-b", 0),
+		mk(3, 2, "alice", "comment-x", 1),
+	}
+	for i := range posts {
+		if err := gdb.Create(&posts[i]).Error; err != nil {
+			t.Fatalf("seed post: %v", err)
+		}
+	}
+
+	// Cache rows for the lite post loader.
+	caches := []models.PostCache{
+		{PostID: 1, Author: "alice", Permlink: "post-a", Category: "test", Title: "A", CreatedAt: now, PayoutAt: now, UpdatedAt: now},
+		{PostID: 2, Author: "bob", Permlink: "post-b", Category: "test", Title: "B", CreatedAt: now, PayoutAt: now, UpdatedAt: now},
+		{PostID: 3, Author: "alice", Permlink: "comment-x", Category: "test", Title: "C", CreatedAt: now, PayoutAt: now, UpdatedAt: now},
+	}
+	for i := range caches {
+		if err := gdb.Create(&caches[i]).Error; err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+	}
+
+	// Blog (alice: own post-a + reblog of bob's post-b) and bob's feed row.
+	feeds := []models.FeedCache{
+		{PostID: 1, AccountID: alice.ID, CreatedAt: now.Add(-2 * time.Hour)},
+		{PostID: 2, AccountID: alice.ID, CreatedAt: now.Add(-1 * time.Hour)},
+		{PostID: 2, AccountID: bob.ID, CreatedAt: now.Add(-3 * time.Hour)},
+		{PostID: 2, AccountID: mustAccountID(t, gdb, "carol"), CreatedAt: now.Add(-4 * time.Hour)},
+	}
+	for i := range feeds {
+		if err := gdb.Create(&feeds[i]).Error; err != nil {
+			t.Fatalf("seed feed: %v", err)
+		}
+	}
+}
+
+func mustAccountID(t *testing.T, gdb *gorm.DB, name string) int64 {
+	t.Helper()
+	var acc models.Account
+	if err := gdb.Where("name = ?", name).First(&acc).Error; err != nil {
+		t.Fatalf("load account %s: %v", name, err)
+	}
+	return acc.ID
+}

--- a/internal/api/hive/notify.go
+++ b/internal/api/hive/notify.go
@@ -180,45 +180,108 @@ func (n *NotifyAPI) UnreadNotifications(ctx *gin.Context, params json.RawMessage
 	}, nil
 }
 
-// renderNotifications renders notifications with full details
+// renderNotifications renders notifications with full details.
+//
+// Related entities (source/destination accounts, posts, communities) are
+// batch-preloaded with one IN query per entity type instead of a per-row
+// lookup, capping the query count regardless of notification volume
+// (previously 4 queries per notification).
 func (n *NotifyAPI) renderNotifications(ctx context.Context, notifications []*models.Notification) ([]interface{}, error) {
 	result := make([]interface{}, 0, len(notifications))
+	if len(notifications) == 0 {
+		return result, nil
+	}
 
-	accountRepo := db.NewAccountRepository(n.repo)
-	postRepo := db.NewPostRepository(n.repo)
-	communityRepo := db.NewCommunityRepository(n.repo)
+	gdb := n.repo.DB()
+
+	// Collect the referenced IDs.
+	accountIDs := make(map[int64]bool)
+	postIDs := make(map[int64]bool)
+	communityIDs := make(map[int64]bool)
+	for _, notif := range notifications {
+		if notif.SrcID.Valid {
+			accountIDs[notif.SrcID.Int64] = true
+		}
+		if notif.DstID.Valid {
+			accountIDs[notif.DstID.Int64] = true
+		}
+		if notif.PostID.Valid {
+			postIDs[notif.PostID.Int64] = true
+		}
+		if notif.CommunityID.Valid {
+			communityIDs[notif.CommunityID.Int64] = true
+		}
+	}
+
+	// Batch query 1: accounts.
+	accountNames := make(map[int64]string, len(accountIDs))
+	if len(accountIDs) > 0 {
+		ids := int64SetToSlice(accountIDs)
+		var accounts []models.Account
+		if err := gdb.WithContext(ctx).Where("id IN ?", ids).
+			Select("id", "name").Find(&accounts).Error; err != nil {
+			return nil, err
+		}
+		for _, acc := range accounts {
+			accountNames[acc.ID] = acc.Name
+		}
+	}
+
+	// Batch query 2: posts (author/permlink).
+	type postRef struct {
+		Author   string
+		Permlink string
+	}
+	postRefs := make(map[int64]postRef, len(postIDs))
+	if len(postIDs) > 0 {
+		ids := int64SetToSlice(postIDs)
+		var posts []models.Post
+		if err := gdb.WithContext(ctx).Where("id IN ?", ids).
+			Select("id", "author", "permlink").Find(&posts).Error; err != nil {
+			return nil, err
+		}
+		for _, post := range posts {
+			postRefs[post.ID] = postRef{Author: post.Author, Permlink: post.Permlink}
+		}
+	}
+
+	// Batch query 3: communities (name/title).
+	type commRef struct {
+		Name  string
+		Title string
+	}
+	commRefs := make(map[int64]commRef, len(communityIDs))
+	if len(communityIDs) > 0 {
+		ids := int64SetToSlice(communityIDs)
+		var comms []models.Community
+		if err := gdb.WithContext(ctx).Where("id IN ?", ids).
+			Select("id", "name", "title").Find(&comms).Error; err != nil {
+			return nil, err
+		}
+		for _, comm := range comms {
+			commRefs[comm.ID] = commRef{Name: comm.Name, Title: comm.Title}
+		}
+	}
 
 	for _, notif := range notifications {
-		// Load related entities
 		var srcName, dstName, author, permlink, communityName, communityTitle string
 
 		if notif.SrcID.Valid {
-			src, err := accountRepo.GetByID(ctx, notif.SrcID.Int64)
-			if err == nil && src != nil {
-				srcName = src.Name
-			}
+			srcName = accountNames[notif.SrcID.Int64]
 		}
-
 		if notif.DstID.Valid {
-			dst, err := accountRepo.GetByID(ctx, notif.DstID.Int64)
-			if err == nil && dst != nil {
-				dstName = dst.Name
-			}
+			dstName = accountNames[notif.DstID.Int64]
 		}
-
 		if notif.PostID.Valid {
-			post, err := postRepo.GetByID(ctx, notif.PostID.Int64)
-			if err == nil && post != nil {
-				author = post.Author
-				permlink = post.Permlink
+			if ref, ok := postRefs[notif.PostID.Int64]; ok {
+				author = ref.Author
+				permlink = ref.Permlink
 			}
 		}
-
 		if notif.CommunityID.Valid {
-			comm, err := communityRepo.GetByID(ctx, notif.CommunityID.Int64)
-			if err == nil && comm != nil {
-				communityName = comm.Name
-				communityTitle = comm.Title
+			if ref, ok := commRefs[notif.CommunityID.Int64]; ok {
+				communityName = ref.Name
+				communityTitle = ref.Title
 			}
 		}
 
@@ -236,6 +299,15 @@ func (n *NotifyAPI) renderNotifications(ctx context.Context, notifications []*mo
 	}
 
 	return result, nil
+}
+
+// int64SetToSlice converts a set of int64 into a slice for IN clauses.
+func int64SetToSlice(set map[int64]bool) []int64 {
+	ids := make([]int64, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 // Helper functions

--- a/internal/api/hive/objects.go
+++ b/internal/api/hive/objects.go
@@ -1,0 +1,287 @@
+package hive
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/steemit/hivemind/internal/models"
+)
+
+// estimatedSp converts VESTS to SP units for display.
+// Mirrors legacy hive_api/common.py estimated_sp.
+func estimatedSp(vests float64) int64 {
+	return int64(vests * 0.0005034)
+}
+
+// accountsByNames loads hive_api account objects by name.
+// Mirrors legacy hive_api/objects.py accounts_by_name. When lite is false the
+// profile fields (location, website, images) are included. An optional
+// observer adds followed/muted context to each account.
+func accountsByNames(ctx context.Context, db *gorm.DB, names []string, observer string, lite bool) ([]map[string]interface{}, error) {
+	if len(names) == 0 {
+		return []map[string]interface{}{}, nil
+	}
+
+	var accounts []models.Account
+	if err := db.WithContext(ctx).
+		Where("name IN ?", names).
+		Find(&accounts).Error; err != nil {
+		return nil, err
+	}
+
+	byID := make(map[int64]map[string]interface{}, len(accounts))
+	for _, acc := range accounts {
+		obj := map[string]interface{}{
+			"id":           acc.ID,
+			"name":         acc.Name,
+			"created":      acc.CreatedAt.Format("2006-01-02"),
+			"sp":           estimatedSp(acc.VoteWeight),
+			"rank":         acc.Rank,
+			"followers":    acc.Followers,
+			"following":    acc.Following,
+			"display_name": nullString(acc.DisplayName),
+			"about":        nullString(acc.About),
+		}
+		if !lite {
+			obj["location"] = nullString(acc.Location)
+			obj["website"] = nullString(acc.Website)
+			obj["profile_image"] = acc.ProfileImage
+			obj["cover_image"] = acc.CoverImage
+		}
+		byID[acc.ID] = obj
+	}
+
+	if observer != "" {
+		if err := appendFollowContexts(ctx, db, byID, observer, !lite); err != nil {
+			return nil, err
+		}
+	}
+
+	// Preserve the input names order (legacy returns rows in query order;
+	// hive_api callers rely on list semantics).
+	out := make([]map[string]interface{}, 0, len(names))
+	for _, name := range names {
+		for _, acc := range accounts {
+			if acc.Name == name {
+				out = append(out, byID[acc.ID])
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// appendFollowContexts adds {followed, muted} context for each account
+// relative to `observer`. Mirrors legacy _follow_contexts.
+func appendFollowContexts(ctx context.Context, db *gorm.DB, accounts map[int64]map[string]interface{}, observer string, includeMute bool) error {
+	var observerAcc models.Account
+	if err := db.WithContext(ctx).
+		Where("name = ?", observer).
+		Select("id").
+		First(&observerAcc).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil
+		}
+		return err
+	}
+
+	ids := make([]int64, 0, len(accounts))
+	for id := range accounts {
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	var follows []models.Follow
+	if err := db.WithContext(ctx).
+		Where("follower = ? AND following IN ?", observerAcc.ID, ids).
+		Find(&follows).Error; err != nil {
+		return err
+	}
+
+	for _, f := range follows {
+		acc, ok := accounts[f.FollowingID]
+		if !ok {
+			continue
+		}
+		contextObj := map[string]interface{}{"followed": f.State == 1 || f.State == 3}
+		if includeMute && (f.State == 2 || f.State == 3) {
+			contextObj["muted"] = true
+		}
+		acc["context"] = contextObj
+	}
+	for _, acc := range accounts {
+		if _, ok := acc["context"]; !ok {
+			acc["context"] = map[string]interface{}{"followed": false}
+		}
+	}
+	return nil
+}
+
+// postsByID loads lite hive_api post objects by ID, returned in input order
+// together with the distinct authors. Mirrors legacy posts_by_id
+// (hive_api/objects.py): {"posts": [...], "accounts": [...]}.
+func postsByID(ctx context.Context, db *gorm.DB, ids []int64, observer string, lite bool) (map[string]interface{}, error) {
+	if len(ids) == 0 {
+		return map[string]interface{}{
+			"posts":    []map[string]interface{}{},
+			"accounts": []map[string]interface{}{},
+		}, nil
+	}
+
+	var caches []models.PostCache
+	if err := db.WithContext(ctx).
+		Where("post_id IN ?", ids).
+		Find(&caches).Error; err != nil {
+		return nil, err
+	}
+	cacheMap := make(map[int64]*models.PostCache, len(caches))
+	for i := range caches {
+		cacheMap[caches[i].PostID] = &caches[i]
+	}
+
+	var posts []models.Post
+	if err := db.WithContext(ctx).
+		Where("id IN ?", ids).
+		Find(&posts).Error; err != nil {
+		return nil, err
+	}
+	postMap := make(map[int64]*models.Post, len(posts))
+	for i := range posts {
+		postMap[posts[i].ID] = &posts[i]
+	}
+
+	authorSet := make(map[string]bool)
+	byID := make(map[int64]map[string]interface{}, len(ids))
+	for _, id := range ids {
+		post, cache := postMap[id], cacheMap[id]
+		if post == nil || cache == nil {
+			continue
+		}
+
+		obj := map[string]interface{}{
+			"id":         id,
+			"author":     cache.Author,
+			"url":        cache.Author + "/" + cache.Permlink,
+			"title":      cache.Title,
+			"payout":     cache.Payout,
+			"promoted":   cache.Promoted,
+			"created_at": cache.CreatedAt.Format(time.RFC3339),
+			"payout_at":  cache.PayoutAt.Format(time.RFC3339),
+			"is_paidout": cache.IsPaidout,
+			"rshares":    cache.RShares,
+			"top_votes":  topVotes(cache.Votes, 5),
+			"thumb_url":  cache.ImgURL,
+			"is_nsfw":    cache.IsNSFW,
+		}
+		if lite {
+			obj["preview"] = cache.Preview
+		} else {
+			obj["body"] = cache.Body
+			obj["updated_at"] = cache.UpdatedAt.Format(time.RFC3339)
+			obj["json_metadata"] = cache.JSON
+		}
+		obj["parent_id"] = nullInt64(post.ParentID)
+		obj["community_id"] = nullInt64(post.CommunityID)
+		obj["category"] = post.Category
+		obj["is_muted"] = post.IsMuted
+		obj["is_valid"] = post.IsValid
+
+		authorSet[cache.Author] = true
+		byID[id] = obj
+	}
+
+	// Recover from cache inconsistency by dropping missing ids (legacy warns).
+	orderedIDs := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := byID[id]; ok {
+			orderedIDs = append(orderedIDs, id)
+		}
+	}
+
+	postList := make([]map[string]interface{}, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		postList = append(postList, byID[id])
+	}
+
+	authors := make([]string, 0, len(authorSet))
+	for name := range authorSet {
+		authors = append(authors, name)
+	}
+	sort.Strings(authors)
+
+	accounts, err := accountsByNames(ctx, db, authors, observer, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"posts":    postList,
+		"accounts": accounts,
+	}, nil
+}
+
+// topVotes parses the votes CSV and returns the `limit` largest by abs
+// rshares as [voter, rshares] pairs. Mirrors legacy _top_votes.
+func topVotes(voteCSV string, limit int) []interface{} {
+	if voteCSV == "" {
+		return []interface{}{}
+	}
+	type vote struct {
+		voter   string
+		rshares int64
+	}
+	votes := make([]vote, 0, 16)
+	for _, line := range strings.Split(voteCSV, "\n") {
+		parts := strings.Split(line, ",")
+		if len(parts) < 2 {
+			continue
+		}
+		rshares, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		votes = append(votes, vote{voter: parts[0], rshares: rshares})
+	}
+	sort.SliceStable(votes, func(i, j int) bool {
+		return abs64(votes[i].rshares) > abs64(votes[j].rshares)
+	})
+	if len(votes) > limit {
+		votes = votes[:limit]
+	}
+	out := make([]interface{}, 0, len(votes))
+	for _, v := range votes {
+		out = append(out, []interface{}{v.voter, v.rshares})
+	}
+	return out
+}
+
+func abs64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// nullString unwraps sql.NullString for JSON output (nil when NULL).
+func nullString(ns sql.NullString) interface{} {
+	if ns.Valid {
+		return ns.String
+	}
+	return nil
+}
+
+// nullInt64 unwraps sql.NullInt64 for JSON output (nil when NULL).
+func nullInt64(v sql.NullInt64) interface{} {
+	if v.Valid {
+		return v.Int64
+	}
+	return nil
+}

--- a/internal/api/hive/public.go
+++ b/internal/api/hive/public.go
@@ -2,25 +2,31 @@ package hive
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/steemit/hivemind/internal/apierrors"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/steemit/hivemind/internal/api/condenser"
+	"github.com/steemit/hivemind/internal/apierrors"
 	"github.com/steemit/hivemind/internal/db"
 )
 
 // PublicAPI provides public Hive API methods
 type PublicAPI struct {
-	repo *db.Repository
+	repo   *db.Repository
+	cursor *condenser.Cursor
 }
 
 // NewPublicAPI creates a new public API
-func NewPublicAPI(repo *db.Repository) *PublicAPI {
-	return &PublicAPI{repo: repo}
+func NewPublicAPI(repo *db.Repository, database *db.DB) *PublicAPI {
+	return &PublicAPI{
+		repo:   repo,
+		cursor: condenser.NewCursor(database.DB),
+	}
 }
 
 // GetAccount handles hive_api.get_account
+// Returns the full account object (non-lite), with observer follow context.
 func (p *PublicAPI) GetAccount(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -31,33 +37,25 @@ func (p *PublicAPI) GetAccount(ctx *gin.Context, params json.RawMessage) (interf
 	observer, _ := pMap["observer"].(string)
 
 	if name == "" {
-		return nil, apierrors.PublicError("missing required parameter: name")
+		return nil, apierrors.PublicError("name cannot be blank")
 	}
-
-	accountRepo := db.NewAccountRepository(p.repo)
-	account, err := accountRepo.GetByName(ctx.Request.Context(), name)
+	name, err := apierrors.ValidAccount(name, false)
 	if err != nil {
 		return nil, err
 	}
-	if account == nil {
+
+	accounts, err := accountsByNames(ctx.Request.Context(), p.repo.DB(), []string{name}, observer, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(accounts) == 0 {
 		return nil, nil
 	}
-
-	// TODO: Build full account object with observer context
-	_ = observer
-
-	return map[string]interface{}{
-		"id":           account.ID,
-		"name":         account.Name,
-		"display_name": account.DisplayName.String,
-		"about":        account.About.String,
-		"reputation":   account.Reputation,
-		"followers":    account.Followers,
-		"following":    account.Following,
-	}, nil
+	return accounts[0], nil
 }
 
 // GetAccounts handles hive_api.get_accounts
+// Returns lite account objects, with observer followed context.
 func (p *PublicAPI) GetAccounts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -65,37 +63,32 @@ func (p *PublicAPI) GetAccounts(ctx *gin.Context, params json.RawMessage) (inter
 	}
 
 	namesInterface, ok := pMap["names"].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("missing or invalid parameter: names")
+	if !ok || len(namesInterface) == 0 {
+		return nil, apierrors.PublicError("names must be a non-empty list")
 	}
-
-	if len(namesInterface) > 100 {
-		return nil, fmt.Errorf("too many names (max 100)")
+	if len(namesInterface) >= 100 {
+		return nil, apierrors.PublicError("too many accounts requested")
 	}
+	observer, _ := pMap["observer"].(string)
 
-	names := make([]string, len(namesInterface))
-	for i, n := range namesInterface {
-		names[i], _ = n.(string)
-	}
-
-	accountRepo := db.NewAccountRepository(p.repo)
-	accounts, err := accountRepo.GetByNames(ctx.Request.Context(), names)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]interface{}, len(accounts))
-	for i, acc := range accounts {
-		result[i] = map[string]interface{}{
-			"id":   acc.ID,
-			"name": acc.Name,
+	names := make([]string, 0, len(namesInterface))
+	for _, n := range namesInterface {
+		name, _ := n.(string)
+		if name == "" {
+			continue
 		}
+		valid, err := apierrors.ValidAccount(name, false)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, valid)
 	}
 
-	return result, nil
+	return accountsByNames(ctx.Request.Context(), p.repo.DB(), names, observer, true)
 }
 
 // ListFollowers handles hive_api.list_followers
+// Returns lite accounts following `account`.
 func (p *PublicAPI) ListFollowers(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -106,35 +99,62 @@ func (p *PublicAPI) ListFollowers(ctx *gin.Context, params json.RawMessage) (int
 	if account == "" {
 		return nil, apierrors.PublicError("missing required parameter: account")
 	}
-
-	start := ""
-	if s, ok := pMap["start"].(string); ok {
-		start = s
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
 	}
-	limit := 50
-	if l, ok := pMap["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 100 {
-			limit = 100
+	start, _ := pMap["start"].(string)
+	if start != "" {
+		start, err = apierrors.ValidAccount(start, false)
+		if err != nil {
+			return nil, err
 		}
 	}
+	observer, _ := pMap["observer"].(string)
+	limit := validLimitParam(pMap, 50, 100)
 
-	// TODO: Query followers from hive_follows
-	_ = start
-	_ = limit
-
-	return []interface{}{}, nil
+	names, err := p.cursor.GetFollowerNames(ctx.Request.Context(), account, start, limit)
+	if err != nil {
+		return nil, err
+	}
+	return accountsByNames(ctx.Request.Context(), p.repo.DB(), names, observer, true)
 }
 
 // ListFollowing handles hive_api.list_following
+// Returns lite accounts `account` follows.
 func (p *PublicAPI) ListFollowing(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// TODO: Implement (query hive_follows in the following direction).
-	// Must NOT delegate to ListFollowers — different semantics, would return
-	// wrong data.
-	return nil, apierrors.PublicError("not implemented")
+	var pMap map[string]interface{}
+	if err := json.Unmarshal(params, &pMap); err != nil {
+		return nil, apierrors.PublicError("invalid parameters format")
+	}
+
+	account, _ := pMap["account"].(string)
+	if account == "" {
+		return nil, apierrors.PublicError("missing required parameter: account")
+	}
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
+	}
+	start, _ := pMap["start"].(string)
+	if start != "" {
+		start, err = apierrors.ValidAccount(start, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	observer, _ := pMap["observer"].(string)
+	limit := validLimitParam(pMap, 50, 100)
+
+	names, err := p.cursor.GetFollowingNames(ctx.Request.Context(), account, start, limit)
+	if err != nil {
+		return nil, err
+	}
+	return accountsByNames(ctx.Request.Context(), p.repo.DB(), names, observer, true)
 }
 
 // ListAllMuted handles hive_api.list_all_muted
+// Returns names of all accounts muted by `account`.
 func (p *PublicAPI) ListAllMuted(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -145,12 +165,16 @@ func (p *PublicAPI) ListAllMuted(ctx *gin.Context, params json.RawMessage) (inte
 	if account == "" {
 		return nil, apierrors.PublicError("missing required parameter: account")
 	}
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
+	}
 
-	// TODO: Query muted accounts from hive_follows where state includes ignore
-	return []string{}, nil
+	return p.cursor.GetMutedNames(ctx.Request.Context(), account)
 }
 
 // ListAccountBlog handles hive_api.list_account_blog
+// Blog feed: the account's own posts plus reblogs.
 func (p *PublicAPI) ListAccountBlog(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
 	var pMap map[string]interface{}
 	if err := json.Unmarshal(params, &pMap); err != nil {
@@ -161,31 +185,139 @@ func (p *PublicAPI) ListAccountBlog(ctx *gin.Context, params json.RawMessage) (i
 	if account == "" {
 		return nil, apierrors.PublicError("missing required parameter: account")
 	}
-
-	limit := 10
-	if l, ok := pMap["limit"].(float64); ok {
-		limit = int(l)
-		if limit > 50 {
-			limit = 50
-		}
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
 	}
+	observer, _ := pMap["observer"].(string)
+	limit := validLimitParam(pMap, 10, 50)
+	lastPost, _ := pMap["last_post"].(string)
 
-	// TODO: Query from feed cache
-	_ = limit
+	startAuthor, startPermlink := splitLastPost(lastPost)
 
-	return []interface{}{}, nil
+	ids, err := p.cursor.GetPostIDsByBlog(ctx.Request.Context(), account, startAuthor, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+	return postsByID(ctx.Request.Context(), p.repo.DB(), ids, observer, true)
 }
 
 // ListAccountPosts handles hive_api.list_account_posts
+// The account's own posts and comments (no reblogs).
 func (p *PublicAPI) ListAccountPosts(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// TODO: Implement (author's own posts only, no reblogs).
-	// Must NOT delegate to ListAccountBlog — different semantics.
-	return nil, apierrors.PublicError("not implemented")
+	var pMap map[string]interface{}
+	if err := json.Unmarshal(params, &pMap); err != nil {
+		return nil, apierrors.PublicError("invalid parameters format")
+	}
+
+	account, _ := pMap["account"].(string)
+	if account == "" {
+		return nil, apierrors.PublicError("missing required parameter: account")
+	}
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
+	}
+	observer, _ := pMap["observer"].(string)
+	limit := validLimitParam(pMap, 10, 50)
+	lastPost, _ := pMap["last_post"].(string)
+
+	_, startPermlink := splitLastPost(lastPost)
+
+	ids, err := p.cursor.GetPostIDsByAccountComments(ctx.Request.Context(), account, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+	return postsByID(ctx.Request.Context(), p.repo.DB(), ids, observer, true)
 }
 
 // ListAccountFeed handles hive_api.list_account_feed
+// Posts and resteems from everyone `account` follows, with reblog attribution.
 func (p *PublicAPI) ListAccountFeed(ctx *gin.Context, params json.RawMessage) (interface{}, error) {
-	// TODO: Implement (personalized feed from follows).
-	// Must NOT delegate to ListAccountBlog — different semantics.
-	return nil, apierrors.PublicError("not implemented")
+	var pMap map[string]interface{}
+	if err := json.Unmarshal(params, &pMap); err != nil {
+		return nil, apierrors.PublicError("invalid parameters format")
+	}
+
+	account, _ := pMap["account"].(string)
+	if account == "" {
+		return nil, apierrors.PublicError("missing required parameter: account")
+	}
+	account, err := apierrors.ValidAccount(account, false)
+	if err != nil {
+		return nil, err
+	}
+	observer, _ := pMap["observer"].(string)
+	limit := validLimitParam(pMap, 10, 50)
+	lastPost, _ := pMap["last_post"].(string)
+
+	startAuthor, startPermlink := splitLastPost(lastPost)
+
+	entries, err := p.cursor.GetPostIDsByFeedWithReblog(ctx.Request.Context(), account, startAuthor, startPermlink, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, 0, len(entries))
+	rebloggers := make(map[int64]string, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.PostID)
+		rebloggers[e.PostID] = e.Accounts
+	}
+
+	result, err := postsByID(ctx.Request.Context(), p.repo.DB(), ids, observer, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge reblogged_by into the post objects (mirrors legacy list_account_feed).
+	if posts, ok := result["posts"].([]map[string]interface{}); ok {
+		for _, post := range posts {
+			pid, _ := post["id"].(int64)
+			csv, ok := rebloggers[pid]
+			if !ok || csv == "" {
+				continue
+			}
+			author, _ := post["author"].(string)
+			seen := make(map[string]bool)
+			rby := make([]string, 0, 4)
+			for _, name := range strings.Split(csv, ",") {
+				if name == "" || name == author || seen[name] {
+					continue
+				}
+				seen[name] = true
+				rby = append(rby, name)
+			}
+			if len(rby) > 0 {
+				post["reblogged_by"] = rby
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// splitLastPost splits an optional "author/permlink" cursor into its parts.
+// Mirrors legacy split_url(allow_empty=True).
+func splitLastPost(lastPost string) (string, string) {
+	if lastPost == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(lastPost, "/", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+// validLimitParam extracts and clamps a limit from a params map.
+func validLimitParam(pMap map[string]interface{}, def, ubound int) int {
+	limit := def
+	if l, ok := pMap["limit"].(float64); ok {
+		limit = int(l)
+	}
+	if limit, err := apierrors.ValidLimit(limit, ubound); err == nil {
+		return limit
+	}
+	return def
 }

--- a/internal/api/objects/bridge_post.go
+++ b/internal/api/objects/bridge_post.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -210,6 +211,79 @@ func (l *PostLoader) LoadPostsKeyed(ctx context.Context, ids []int64, truncateBo
 	return postsByID, nil
 }
 
+// LoadPostsBridge loads posts by ID and returns them as an ordered array of
+// bridge_api post objects (same shape as LoadPostsKeyed). Mirrors legacy
+// bridge objects.load_posts.
+func (l *PostLoader) LoadPostsBridge(ctx context.Context, ids []int64, truncateBody int) ([]map[string]interface{}, error) {
+	byID, err := l.LoadPostsKeyed(ctx, ids, truncateBody)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]interface{}, 0, len(ids))
+	for _, id := range ids {
+		if obj, ok := byID[id]; ok {
+			out = append(out, obj)
+		}
+	}
+	return out, nil
+}
+
+// LoadPostsReblogsBridge extends LoadPostsBridge with reblog attribution:
+// rebloggers is a post_id → CSV-of-names map (from pids_by_feed_with_reblog's
+// string_agg). The post author is excluded from the list, matching legacy
+// bridge objects.load_posts_reblogs.
+func (l *PostLoader) LoadPostsReblogsBridge(ctx context.Context, ids []int64, rebloggers map[int64]string, truncateBody int) ([]map[string]interface{}, error) {
+	posts, err := l.LoadPostsBridge(ctx, ids, truncateBody)
+	if err != nil {
+		return nil, err
+	}
+	for _, post := range posts {
+		csv, ok := rebloggers[post["post_id"].(int64)]
+		if !ok || csv == "" {
+			continue
+		}
+		author, _ := post["author"].(string)
+		seen := make(map[string]bool)
+		rby := make([]string, 0, 4)
+		for _, name := range splitCommas(csv) {
+			if name == "" || name == author || seen[name] {
+				continue
+			}
+			seen[name] = true
+			rby = append(rby, name)
+		}
+		if len(rby) > 0 {
+			post["reblogged_by"] = rby
+		}
+	}
+	return posts, nil
+}
+
+// sbdAmount parses a steemd-style SBD amount ("1.234 SBD" string, bare
+// number, or {amount, precision, nai} object) into its numeric value.
+// Mirrors legacy utils/normalize.py sbd_amount/parse_amount.
+func sbdAmount(value interface{}) float64 {
+	switch v := value.(type) {
+	case float64:
+		return v
+	case string:
+		fields := strings.Fields(v)
+		if len(fields) == 0 {
+			return 0
+		}
+		amt, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			return 0
+		}
+		return amt
+	case map[string]interface{}:
+		if amt, ok := v["amount"].(float64); ok {
+			return amt / 1000 // asset amount is fixed-point with precision 3
+		}
+	}
+	return 0
+}
+
 // buildBridgePost builds a single bridge_api-shape post object.
 // Mirrors legacy _condenser_post_object (bridge_api/objects.py:231).
 func (l *PostLoader) buildBridgePost(post *models.Post, cache *models.PostCache, authorRep float64, truncateBody int) map[string]interface{} {
@@ -234,24 +308,35 @@ func (l *PostLoader) buildBridgePost(post *models.Post, cache *models.PostCache,
 	// Parse raw_json for import fields.
 	rawFields := parseRawJSON(cache.RawJSON)
 
+	// Payout split: pending before payout, author+curator after.
+	var pendingPayout, authorPayout float64
+	if cache.IsPaidout {
+		authorPayout = cache.Payout
+	} else {
+		pendingPayout = cache.Payout
+	}
+
 	obj := map[string]interface{}{
-		"post_id":              post.ID,
-		"author":               post.Author,
-		"permlink":             post.Permlink,
-		"category":             post.Category,
-		"title":                cache.Title,
-		"body":                 body,
-		"json_metadata":        jsonMeta,
-		"created":              post.CreatedAt.Format(time.RFC3339),
-		"updated":              cache.UpdatedAt.Format(time.RFC3339),
-		"depth":                post.Depth,
-		"children":             cache.Children,
-		"net_rshares":          cache.RShares,
-		"is_paidout":           cache.IsPaidout,
-		"payout_at":            cache.PayoutAt.Format(time.RFC3339),
-		"payout":               cache.Payout,
-		"pending_payout_value": formatAmount(cache.Payout),
-		"author_payout_value":  formatAmount(0), // TODO: compute from raw_json when paid
+		"post_id":       post.ID,
+		"author":        post.Author,
+		"permlink":      post.Permlink,
+		"category":      post.Category,
+		"title":         cache.Title,
+		"body":          body,
+		"json_metadata": jsonMeta,
+		"created":       post.CreatedAt.Format(time.RFC3339),
+		"updated":       cache.UpdatedAt.Format(time.RFC3339),
+		"depth":         post.Depth,
+		"children":      cache.Children,
+		"net_rshares":   cache.RShares,
+		"is_paidout":    cache.IsPaidout,
+		"payout_at":     cache.PayoutAt.Format(time.RFC3339),
+		"payout":        cache.Payout,
+		// Payout split mirrors legacy bridge _condenser_post_object: before
+		// payout the whole amount is pending; after payout the author value is
+		// recomputed from raw_json.curator_payout_value below.
+		"pending_payout_value": formatAmount(pendingPayout),
+		"author_payout_value":  formatAmount(authorPayout),
 		"curator_payout_value": formatAmount(0),
 		"promoted":             formatAmount(cache.Promoted),
 		"replies":              []interface{}{},
@@ -268,6 +353,16 @@ func (l *PostLoader) buildBridgePost(post *models.Post, cache *models.PostCache,
 	// Merge raw_json import fields if available.
 	for k, v := range rawFields {
 		obj[k] = v
+	}
+
+	// For paid posts, split the total payout between author and curators
+	// using the curator payout recorded at payout time (raw_json).
+	if cache.IsPaidout {
+		if raw, ok := rawFields["curator_payout_value"]; ok {
+			curator := sbdAmount(raw)
+			obj["author_payout_value"] = formatAmount(cache.Payout - curator)
+			obj["curator_payout_value"] = formatAmount(curator)
+		}
 	}
 
 	// URL: prefer raw_json url, fall back to constructed.

--- a/internal/api/objects/post.go
+++ b/internal/api/objects/post.go
@@ -234,57 +234,6 @@ func payoutDate(isPaidout bool, payoutAt time.Time) interface{} {
 	return payoutAt.Format(time.RFC3339)
 }
 
-// LoadPostsReblogs loads posts with reblog information
-func (l *PostLoader) LoadPostsReblogs(ctx context.Context, idsWithReblogs [][]int64, truncateBody int) ([]map[string]interface{}, error) {
-	// Extract all post IDs and collect reblogger account IDs for batch lookup
-	allIDs := make([]int64, 0, len(idsWithReblogs))
-	rebloggerIDs := make([]int64, 0, len(idsWithReblogs))
-	idToRebloggerID := make(map[int64]int64) // post_id -> reblogger_id
-
-	for _, pair := range idsWithReblogs {
-		if len(pair) >= 2 {
-			postID := pair[0]
-			rebloggerID := pair[1]
-			allIDs = append(allIDs, postID)
-			rebloggerIDs = append(rebloggerIDs, rebloggerID)
-			idToRebloggerID[postID] = rebloggerID
-		}
-	}
-
-	// Batch-load all reblogger account names in ONE query (was N+1).
-	idToName := make(map[int64]string)
-	if len(rebloggerIDs) > 0 {
-		var accounts []models.Account
-		if err := l.db.WithContext(ctx).
-			Where("id IN ?", rebloggerIDs).
-			Select("id", "name").
-			Find(&accounts).Error; err == nil {
-			for _, acc := range accounts {
-				idToName[acc.ID] = acc.Name
-			}
-		}
-	}
-
-	// Load posts normally
-	posts, err := l.LoadPosts(ctx, allIDs, truncateBody)
-	if err != nil {
-		return nil, err
-	}
-
-	// Add reblog information
-	for i := range posts {
-		postID := posts[i]["id"].(int64)
-		if rebloggerID, ok := idToRebloggerID[postID]; ok {
-			if reblogger, ok := idToName[rebloggerID]; ok {
-				rebloggedBy, _ := posts[i]["reblogged_by"].([]interface{})
-				posts[i]["reblogged_by"] = append(rebloggedBy, reblogger)
-			}
-		}
-	}
-
-	return posts, nil
-}
-
 // getRebloggedBy gets account names that reblogged a post
 func (l *PostLoader) getRebloggedBy(ctx context.Context, postID int64) []interface{} {
 	// Create a temporary repository to query reblogs

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/steemit/hivemind/internal/api/hive"
 	"github.com/steemit/hivemind/internal/cache"
 	"github.com/steemit/hivemind/internal/db"
+	"github.com/steemit/hivemind/internal/steem"
 	"github.com/steemit/hivemind/pkg/logging"
 	"github.com/steemit/hivemind/pkg/telemetry"
 )
@@ -24,8 +25,10 @@ type Router struct {
 	logger  *zap.Logger
 }
 
-// NewRouter creates a new API router
-func NewRouter(database *db.DB, redisCache *cache.Cache) *Router {
+// NewRouter creates a new API router. The steemd client is optional (nil
+// disables steemd-backed methods like get_transaction);
+// recommendCommunities is the HIVE_RECOMMEND_COMMUNITIES comma list.
+func NewRouter(database *db.DB, redisCache *cache.Cache, steemd *steem.Client, recommendCommunities string) *Router {
 	handler := NewJSONRPCHandler()
 	router := &Router{
 		handler: handler,
@@ -35,7 +38,7 @@ func NewRouter(database *db.DB, redisCache *cache.Cache) *Router {
 	}
 
 	// Register all API methods
-	router.registerMethods()
+	router.registerMethods(steemd, recommendCommunities)
 
 	return router
 }
@@ -51,7 +54,7 @@ func (r *Router) SetupRoutes(engine *gin.Engine) {
 }
 
 // registerMethods registers all API methods
-func (r *Router) registerMethods() {
+func (r *Router) registerMethods(steemd *steem.Client, recommendCommunities string) {
 	repo := db.NewRepository(r.db.DB)
 
 	// Hive core API
@@ -71,7 +74,7 @@ func (r *Router) registerMethods() {
 	r.handler.RegisterMethod("condenser_api.get_following_by_page", condenserFollow.GetFollowingByPage)
 	r.handler.RegisterMethod("condenser_api.get_content", condenserContent.GetContent)
 	r.handler.RegisterMethod("condenser_api.get_content_replies", condenserContent.GetContentReplies)
-	
+
 	// Discussion queries
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_trending", condenserDiscussions.GetDiscussionsByTrending)
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_hot", condenserDiscussions.GetDiscussionsByHot)
@@ -79,23 +82,23 @@ func (r *Router) registerMethods() {
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_promoted", condenserDiscussions.GetDiscussionsByPromoted)
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_blog", condenserDiscussions.GetDiscussionsByBlog)
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_feed", condenserDiscussions.GetDiscussionsByFeed)
-	
+
 	// Blog and Tags API
 	condenserBlog := condenser.NewBlogAPI(repo, r.db)
 	condenserTags := condenser.NewTagsAPI(repo, r.db)
-	
+
 	r.handler.RegisterMethod("condenser_api.get_blog", condenserBlog.GetBlog)
 	r.handler.RegisterMethod("condenser_api.get_blog_entries", condenserBlog.GetBlogEntries)
 	r.handler.RegisterMethod("condenser_api.get_trending_tags", condenserTags.GetTrendingTags)
 	r.handler.RegisterMethod("condenser_api.get_account_reputations", condenserTags.GetAccountReputations)
-	
+
 	// Follow API aliases for blog
 	r.handler.RegisterMethod("follow_api.get_blog", condenserBlog.GetBlog)
 	r.handler.RegisterMethod("follow_api.get_blog_entries", condenserBlog.GetBlogEntries)
-	
+
 	// Misc API
-	condenserMisc := condenser.NewMiscAPI(repo, r.db)
-	
+	condenserMisc := condenser.NewMiscAPI(repo, r.db, steemd)
+
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_comments", condenserMisc.GetDiscussionsByComments)
 	r.handler.RegisterMethod("condenser_api.get_replies_by_last_update", condenserMisc.GetRepliesByLastUpdate)
 	r.handler.RegisterMethod("condenser_api.get_discussions_by_author_before_date", condenserMisc.GetDiscussionsByAuthorBeforeDate)
@@ -104,7 +107,7 @@ func (r *Router) registerMethods() {
 	r.handler.RegisterMethod("condenser_api.get_transaction", condenserMisc.GetTransaction)
 	r.handler.RegisterMethod("condenser_api.get_state", condenserMisc.GetState)
 	r.handler.RegisterMethod("condenser_api.get_account_votes", condenserMisc.GetAccountVotes)
-	
+
 	// Tags API aliases
 	r.handler.RegisterMethod("tags_api.get_discussions_by_trending", condenserDiscussions.GetDiscussionsByTrending)
 	r.handler.RegisterMethod("tags_api.get_discussions_by_hot", condenserDiscussions.GetDiscussionsByHot)
@@ -121,7 +124,7 @@ func (r *Router) registerMethods() {
 	// Bridge API
 	bridgePost := bridge.NewPostAPI(repo)
 	bridgeProfile := bridge.NewProfileAPI(repo)
-	bridgeRanked := bridge.NewRankedAPI(repo, r.db, r.cache)
+	bridgeRanked := bridge.NewRankedAPI(repo, r.db, r.cache, recommendCommunities)
 	bridgeStats := bridge.NewStatsAPI(repo, r.db)
 
 	r.handler.RegisterMethod("bridge.get_post", bridgePost.GetPost)
@@ -135,8 +138,8 @@ func (r *Router) registerMethods() {
 	r.handler.RegisterMethod("bridge.get_payout_stats", bridgeStats.GetPayoutStats)
 
 	// Hive API
-	hivePublic := hive.NewPublicAPI(repo)
-	hiveCommunity := hive.NewCommunityAPI(repo)
+	hivePublic := hive.NewPublicAPI(repo, r.db)
+	hiveCommunity := hive.NewCommunityAPI(repo, recommendCommunities)
 	hiveNotify := hive.NewNotifyAPI(repo)
 
 	r.handler.RegisterMethod("hive_api.get_account", hivePublic.GetAccount)
@@ -205,4 +208,3 @@ func (r *Router) dbHeadState(c *gin.Context, params json.RawMessage) (interface{
 		"db_head_age":   age,
 	}, nil
 }
-

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -192,6 +192,26 @@ func (r *PostStatusRepository) IsPostHidden(ctx context.Context, postID int64) (
 	return count > 0, nil
 }
 
+// GetHiddenPostIDs returns the set of article-blocked (list_type=1) post IDs
+// among `ids` in a single query. Mirrors legacy hide_pids_by_ids, used to
+// filter ranked/blog/payout result lists.
+func (r *PostStatusRepository) GetHiddenPostIDs(ctx context.Context, ids []int64) (map[int64]bool, error) {
+	hidden := make(map[int64]bool)
+	if len(ids) == 0 {
+		return hidden, nil
+	}
+	var rows []int64
+	if err := r.db.WithContext(ctx).Model(&models.PostStatus{}).
+		Where("list_type = ? AND post_id IN ?", models.PostStatusArticleBlock, ids).
+		Pluck("post_id", &rows).Error; err != nil {
+		return nil, err
+	}
+	for _, id := range rows {
+		hidden[id] = true
+	}
+	return hidden, nil
+}
+
 // Create creates a new post
 func (r *PostRepository) Create(ctx context.Context, post *models.Post) error {
 	return r.db.WithContext(ctx).Create(post).Error


### PR DESCRIPTION
## Summary

Fills in the remaining API-layer stubs (plan PR#10, KR6), ported against the legacy Python implementation as the behavioral authority.

### condenser_api
- `get_discussions_by_comments`, `get_replies_by_last_update`, `get_discussions_by_author_before_date`, `get_discussions_by_feed` (newly implemented, was not-implemented), `get_trending_tags` (SQL aggregation), `get_transaction` (hive_trxid_block_num → steemd block lookup; server wires an optional steemd client)
- `get_blog` / `get_blog_entries`: real entry_id-descending pagination via `pids_by_blog_by_index`; entries return the lightweight shape
- payout discussions return full post objects (previously `{"id": n}` placeholders)
- `get_state` stays an explicit not-implemented (retired condenser-frontend surface, per repo placeholder policy)

### bridge
- `get_account_posts`: all six sorts (blog/feed/posts/comments/replies/payout) with hidden-post filtering, reblog attribution, and author-block short-circuit; payout reads `hive_posts_cache_temp`
- `get_ranked_posts`: full bridge post objects (incl. new `muted` sort), cache unchanged
- `get_post` full object; `get_post_header` title from cache; `get_trending_topics` aligned with legacy (recommended communities + fixed tags)

### hive_api
- All 8 community methods (team/observer context, full-text search, rank/new/subs sorts, pagination)
- All 6 list methods (list_followers/following/all_muted/account_blog/posts/feed) with new accounts/posts lite loaders (`hive/objects.go`)
- `renderNotifications` batch-preloads accounts/posts/communities: 4 queries per notification → 3 total

### Cross-cutting
- Bridge post payout split: `pending_payout_value` zeroes after payout; when paid, `author_payout_value = payout − curator_payout(raw_json)` and `curator_payout_value` parsed from raw_json
- Unified condenser parameter parsing (object / nested-query / positional with per-method key layouts), mirroring legacy `nested_query_compat` + `_strict_query`
- 10 new cursor queries ported from legacy `pids_by_*`; `GetHiddenPostIDs` batch moderation filter

## Test plan

- [x] `go build ./...`, `go vet ./...` clean; self-recursion grep clean
- [x] Unit tests: parameter-form parsing, param-validation-before-DB guard
- [x] Integration tests against real Postgres (per-package isolated DBs): bridge all-sorts suite, hive community+public suite, condenser misc/blog/tags suite
- [x] Full `go test -p 1 ./...` green (incl. existing indexer/db suites)
- [x] Live binary smoke: 9 endpoints via curl with expected shapes; PublicError passthrough verified